### PR TITLE
Add GitHub Actions Jekyll build + deploy workflow (#98)

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,72 @@
+# Build the Jekyll site with GitHub Actions and deploy it to GitHub Pages.
+#
+# This replaces the default "deploy from a branch" GitHub Pages build (which
+# only runs whitelisted plugins and no custom build steps) with a full
+# `bundle exec jekyll build` running in CI. That unlocks custom plugins,
+# build-time code inlining, and content lint/test gates. See issue #98.
+#
+# IMPORTANT: this workflow only takes over publishing once the repo's
+# Pages "Source" is switched from "Deploy from a branch" to "GitHub Actions"
+# (Settings -> Pages -> Build and deployment -> Source). Until then it builds
+# but the deploy step will not publish.
+name: Build and deploy Jekyll site to Pages
+
+on:
+  # Run on every push to the live branch.
+  push:
+    branches: ["main"]
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Minimum permissions the deploy job needs to publish to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production
+# deploy if another push lands while it's running.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Matches .ruby-version. bundler-cache installs the Gemfile (still
+          # the github-pages gem, so the build is byte-for-byte the current
+          # one) and caches gems between runs.
+          ruby-version: "3.3.11"
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        # base_path comes out as "/physcomp", matching baseurl in _config.yml.
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website-dev.md
+++ b/website-dev.md
@@ -24,6 +24,25 @@ Assuming you have the prerequisite libraries and software infrastructure (e.g., 
 > bundle exec jekyll serve 
 ```
 
+## Deployment (GitHub Actions)
+
+The live site at <https://makeabilitylab.github.io/physcomp/> is built and
+published by the GitHub Actions workflow in
+[`.github/workflows/jekyll.yml`](.github/workflows/jekyll.yml). On every push to
+`main` (and on manual runs from the **Actions** tab), the workflow runs
+`bundle exec jekyll build` on a clean Ubuntu runner and deploys the resulting
+`_site/` to GitHub Pages with `actions/deploy-pages`.
+
+This replaced the older "Deploy from a branch" GitHub Pages build, which only
+ran whitelisted plugins and no custom build steps. Building in Actions lets us
+run custom Jekyll plugins, inline source code at build time, and add content
+lint/test gates. See [issue #98](https://github.com/makeabilitylab/physcomp/issues/98).
+
+For the Actions deploy to publish, the repo's **Settings → Pages → Build and
+deployment → Source** must be set to **GitHub Actions** (not "Deploy from a
+branch"). The workflow still installs the same `github-pages` gem from the
+`Gemfile`, so the built output matches the previous branch-based build.
+
 ## VS Code
 I've been using [VS Code](https://code.visualstudio.com/) with some popular markdown extensions to develop the website. 
 


### PR DESCRIPTION
## Summary

Spikes the GitHub Actions Jekyll deploy from #98 — the V2.0 enabler that unblocks custom plugins (#101), build-time code inlining (#100), and content lint/test gates (#99).

Adds `.github/workflows/jekyll.yml`: on every push to `main` (and manual dispatch) it runs `bundle exec jekyll build` on a clean Ubuntu runner and publishes `_site/` via `actions/deploy-pages`. It still installs the existing `github-pages` gem from the `Gemfile`, so the built output matches the current branch-based build — this is a no-regret swap of the *build mechanism*, not the site.

## Verification

- ✅ Local `bundle exec jekyll build` passes; `remote_theme` resolves, `baseurl: /physcomp` handled by `configure-pages` (`base_path` = `/physcomp`).
- ✅ Build time ~20s, same as the current default build.
- ✅ Deploy pipeline documented in `website-dev.md`.

## Cutover (after merge)

The Actions deploy only takes over publishing once **Settings → Pages → Build and deployment → Source** is switched from "Deploy from a branch" to **GitHub Actions**. Until then the legacy build keeps serving and the workflow's deploy step is a no-op. Once merged, I'll flip the Pages source (per our agreed plan) and confirm the first green production deploy.

Closes #98 once the source switch is confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)