### PR TITLE
Tier-0 V2.0 quick fixes: sitemap, robots.txt, LaTeX + nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,13 @@ url: "https://makeabilitylab.github.io" # the base hostname & protocol for your 
 # For copy button on code
 enable_copy_code_button: true
 
+# Jekyll plugins. jekyll-sitemap generates /sitemap.xml (submittable to search
+# engines) to help indexing. It ships with the github-pages gem and is on the
+# GitHub Pages plugin whitelist, so it works under both the legacy build and the
+# GitHub Actions build (#98).
+plugins:
+  - jekyll-sitemap
+
 # custom site variables
 arduino_github_baseurl: "https://makeabilitylab.github.io/physcomp/"
 comments: false

--- a/advancedio/smoothing-input.md
+++ b/advancedio/smoothing-input.md
@@ -204,7 +204,7 @@ $$
 S_{i} =
 \begin{cases}
     X_{1} & \text{if i = 1}\\
-    \alpha \cdot X_{i} + (1 - \alpha) \cdot S_{i-1} & \text{if i $>$ 1}
+    \alpha \cdot X_{i} + (1 - \alpha) \cdot S_{i-1} & \text{if i > 1}
 \end{cases}
 $$
 

--- a/esp32/esp32-ide.md
+++ b/esp32/esp32-ide.md
@@ -196,6 +196,9 @@ With your IDE set up, you're ready to start building ESP32 projects!
 
 Head back to [Lesson 1: Introduction to the ESP32](esp32.md) to learn about the hardware, or jump straight to [Lesson 2: Blinking an LED](led-blink.md) if you're ready to write code.
 
-<span class="fs-6">
-[Back to: Introduction to the ESP32](esp32.md){: .btn .btn-outline }
-</span>
+<nav class="lesson-nav" aria-label="Lesson navigation">
+  <a href="esp32.html" class="nav-prev">
+    <div class="nav-label">&larr; Previous Lesson</div>
+    <div class="nav-title">Introduction to the ESP32</div>
+  </a>
+</nav>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://makeabilitylab.github.io/physcomp/sitemap.xml


### PR DESCRIPTION
## Summary

Punch-list item B — the fast, mechanical, no-regret Tier-0 fixes toward V2.0. Independent of the Actions-deploy PR (#104).

### Changes
- **`jekyll-sitemap` + `robots.txt`** (helps #72 indexing). Enabled the plugin in `_config.yml` (it ships with the `github-pages` gem and is whitelisted, so it works under both the legacy and Actions builds). Added a root `robots.txt` pointing at the generated sitemap.
- **LaTeX fix** in `advancedio/smoothing-input.md`: a nested `$>$` inside a `$$…$$` block broke MathJax parsing. Replaced with a literal `>` to match the `\text{if i = 1}` case just above it.
- **Nav migration** in `esp32/esp32-ide.md`: converted the old `.btn` "Back to" button to the standard card-style `<nav class="lesson-nav">`, matching every other esp32 lesson.

### Verification
- ✅ Clean `bundle exec jekyll build` (~20s).
- ✅ `_site/sitemap.xml` generated with correct absolute URLs, e.g. `https://makeabilitylab.github.io/physcomp/advancedio/accel.html` (baseurl preserved).
- ✅ `_site/robots.txt` published with the sitemap line.
- ✅ `esp32-ide.html` now renders `lesson-nav`/`nav-prev` (no `btn-outline`).

### Notes
- `robots.txt` on a project page is served at `/physcomp/robots.txt`; crawlers only honor the authoritative one at the org root (`makeabilitylab.github.io/robots.txt`). The real indexing win here is the `sitemap.xml`, which is directly submittable to Google Search Console.
- The nav migration script (`scripts/update_lesson_nav.py`) doesn't recognize this single "Back to" button form (and has a Windows-only cp1252 crash in its summary print). It did flag two *other* still-stale pages — `communication/p5js-serial-io.md` and `cpx/capacitive-touch.md` — out of scope here but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)