### PR TITLE
Add /version.json build stamp to track deploys

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -51,6 +51,20 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
+      - name: Stamp build version
+        # Write build metadata consumed by version.json so we can see exactly
+        # which commit/run is live (https://makeabilitylab.github.io/physcomp/version.json).
+        run: |
+          mkdir -p _data
+          cat > _data/version.yml <<EOF
+          short_sha: $(git rev-parse --short HEAD)
+          sha: ${{ github.sha }}
+          ref: ${{ github.ref_name }}
+          run_number: "${{ github.run_number }}"
+          run_id: "${{ github.run_id }}"
+          built_at: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          EOF
+
       - name: Build with Jekyll
         # base_path comes out as "/physcomp", matching baseurl in _config.yml.
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ codekit-config.json
 # macOS
 .DS_Store
 
+# Generated at build time by the Actions deploy (Stamp build version step);
+# never commit it. version.json renders from it. See .github/workflows/jekyll.yml.
+_data/version.yml
+
 # Jekyll generated files
 .jekyll-cache
 .jekyll-metadata

--- a/version.json
+++ b/version.json
@@ -1,0 +1,11 @@
+---
+sitemap: false
+---
+{
+  "short_sha": "{{ site.data.version.short_sha }}",
+  "sha": "{{ site.data.version.sha }}",
+  "ref": "{{ site.data.version.ref }}",
+  "run_number": "{{ site.data.version.run_number }}",
+  "run_id": "{{ site.data.version.run_id }}",
+  "built_at": "{{ site.data.version.built_at }}"
+}


### PR DESCRIPTION
Adds a `version.json` endpoint that reports exactly which commit/build is live, so we can confirm a push actually deployed (and monitor it programmatically).

## What
- New **"Stamp build version"** step in `.github/workflows/jekyll.yml` writes `_data/version.yml` (short SHA, full SHA, ref, run number/id, UTC build time) from the Actions context, before `jekyll build`.
- New root **`version.json`** renders that data → served at `https://makeabilitylab.github.io/physcomp/version.json`.
- `_data/version.yml` is **gitignored** (generated in CI, never committed). Excluded from `sitemap.xml`.

## Notes
- On local builds there's no `_data/version.yml`, so fields render empty — expected.
- Verified locally by stubbing `_data/version.yml` and building: JSON populates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)