### PR TITLE
Accessibility content sweep: media titles, video aria-labels, image alt text (#110)

### DIFF
--- a/advancedio/addressable-leds.md
+++ b/advancedio/addressable-leds.md
@@ -308,7 +308,7 @@ The wiring for addressable LEDs is simple—just three connections:
 
 ### Preparing the LED stick
 
-![](assets/images/RGBLEDStick_8LEDs_SolderPadsAndLEDS.png)
+![Back and front views of an 8-LED WS2812B stick, showing the solder pads and the row of addressable RGB LEDs](assets/images/RGBLEDStick_8LEDs_SolderPadsAndLEDS.png)
 **Figure.** The back and front sides of an 8-LED WS2812B stick. We will need to solder either jumper wires or header pins to the pads.
 {: .fs-1 }
 
@@ -413,7 +413,7 @@ void loop() {
 
 If your colors look wrong (*e.g.,* you asked for red but got green), try changing `NEO_GRB` to `NEO_RGB` in the strip constructor. This is the most common issue students encounter!
 
-![](assets/images/AddressableLEDs_RainbowStatic8.png)
+![An 8-LED addressable RGB stick lit up in a static rainbow gradient from red through green to blue](assets/images/AddressableLEDs_RainbowStatic8.png)
 **Figure.** An image of the RGB LED stick running the above code. You can also view and play with this on [Tinkercad](https://www.tinkercad.com/things/lSqArYGju94-neopixel-strip-8-static-rainbow). See our [RainbowStatic8.ino](https://github.com/makeabilitylab/arduino/blob/master/AddressableLEDs/NeoPixel/RainbowStatic8/RainbowStatic8.ino) and [RainbowStatic.ino](https://github.com/makeabilitylab/arduino/blob/master/AddressableLEDs/NeoPixel/RainbowStatic/RainbowStatic.ino) sketches in GitHub.
 {: .fs-1 }
 

--- a/advancedio/smoothing-input.md
+++ b/advancedio/smoothing-input.md
@@ -23,7 +23,7 @@ usetocbot: true
 
 By now, you may have noticed that your analog input data can be noisy. How can we smooth our input and what factors should we consider?
 
-<video autoplay loop muted playsinline>
+<video aria-label="A noisy analog input signal (blue) being smoothed in real time by a moving average filter with a window size of 10 (red), graphed in the Arduino Serial Plotter" autoplay loop muted playsinline>
   <source src="assets/videos/MovingAverageFilterWindowSize10-Optimized.mp4" type="video/mp4" />
 </video>
 
@@ -52,7 +52,7 @@ When reading sensor data using analog input pins on a microcontroller (*e.g.,* v
 
 Even with a simple potentiometer, we can observe noise on our input pin. In the video below, we are **not** touching the potentiometer and yet the analog input is oscillating between 142 and 143 (0.694V and 0.699V)—shown as the blue line. You may have experienced this too in your own potentiometer-based projects or in the [Arduino potentiometer lesson](../arduino/potentiometers.md). In this case, we fixed this "input noise" by smoothing the signal using a moving average filter—shown in red—which we will describe in this lesson.
 
-<video autoplay loop muted playsinline>
+<video aria-label="A potentiometer's raw analog input (blue) oscillating between 142 and 143 while untouched, with the noise removed by a moving average filter of window size 10 (red)" autoplay loop muted playsinline>
   <source src="assets/videos/PotentiometerOscillatingWithNoInputButFixedWithMovingAverage-Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** In this video, we're graphing the raw analog input (blue line) from a potentiometer along with a "smoothed" version (red line). Although we're not touching or using the potentiometer, the analog input is oscillating between 142 and 143 (0.694V and 0.699V). We smooth this noise using a moving average filter (window size = 10)—shown in red. Note that, depending on the oscillation pattern, a different window size or smoothing approach may be necessary. Read more about potentiometer noise [here](https://passive-components.eu/resistors-potentiometers-basic-principles/). Graph made with the built-in [Arduino Serial Plotter](https://diyrobocars.com/2020/05/04/arduino-serial-plotter-the-missing-manual/).
@@ -92,7 +92,7 @@ This filter is a type of **low-pass** filter because it smooths out (eliminates)
 
 You can control the filter's performance by tweaking the size of the sliding window. The animation below demonstrates a sliding window of size 3. The blue line corresponds to the raw input signal; the orange line, the smoothed filter output. For illustrative purposes, we only show the sliding window applied to a subset of data.
 
-<video autoplay loop muted playsinline>
+<video aria-label="An animation illustrating a moving average filter with a window size of 3 sliding over a raw input signal (blue) to produce the smoothed output (orange)" autoplay loop muted playsinline>
   <source src="assets/videos/MovingAverageFilter_PowerPointAnimation_TrimmedAndCropped.mp4" type="video/mp4" />
 </video>
 **Video** This video illustrates a moving average filter of window size 3 over a subset of data. Animation made in PowerPoint.
@@ -109,7 +109,7 @@ Below, we compute three different moving average filter window sizes: 5, 10, and
 
 <!-- The object-oriented filtering approach makes it easy to test and compare the effect of different window sizes on the filtered output. -->
 
-<video autoplay loop muted playsinline>
+<video aria-label="Raw analog input (blue) graphed alongside moving average filter output for three window sizes: 5 (red), 10 (green), and 20 (yellow), in the Arduino Serial Plotter" autoplay loop muted playsinline>
   <source src="assets/videos/MovingAverageWithThreeWindowSizes-Optimized.mp4" type="video/mp4" />
 </video>
 **Video** This video graphs raw analog input (blue) and filtered output from three different moving average window sizes: 5 (red line), 10 (green), and 20 (yellow). To produce this video, we used [this code](https://github.com/makeabilitylab/arduino/blob/master/Filters/MovingAverageFilterWindowSizeDemo/MovingAverageFilterWindowSizeDemo.ino) and the [Arduino Serial Plotter](https://diyrobocars.com/2020/05/04/arduino-serial-plotter-the-missing-manual/). You should [try it](https://github.com/makeabilitylab/arduino/blob/master/Filters/MovingAverageFilterWindowSizeDemo/MovingAverageFilterWindowSizeDemo.ino) yourself!
@@ -190,7 +190,7 @@ Below, we've included sample weights for both linear and exponential weighting s
 
 | Linear Weights | Exponential Weights |
 |:----------------:|:-------------:|
-| ![](assets/images/WeightedMovingAverage_WindowSize15_Wikipedia.png) |  ![](assets/images/ExponentialMovingAverageWeights_WindowSize15_Wikipedia.png)  |
+| ![Bar chart of linearly decreasing weights across a moving average window of size 15](assets/images/WeightedMovingAverage_WindowSize15_Wikipedia.png) |  ![Bar chart of exponentially decreasing weights across a moving average window of size 15](assets/images/ExponentialMovingAverageWeights_WindowSize15_Wikipedia.png)  |
 | Linearly decreasing weights for window size 15 | Exponentially decreasing weights for window size 15|
 
 **Figure.** Images from [Wikipedia](https://en.wikipedia.org/wiki/Moving_average).
@@ -217,7 +217,7 @@ Where:
 
 The coefficient $$\alpha$$ determines the exponential dropoff. A higher $$\alpha$$ weights more recent data more. For example, the video below shows EWMA performance with $$\alpha$$ equal to 0.5 (red line), 0.1 (green line), and 0.01 (yellow line). Notice how closely the $$\alpha=0.5$$ EWMA filter tracks the underlying raw signal whereas the $$\alpha=0.01$$ filter is quite distorted and lagged. The $$\alpha=0.1$$ filter may still be appropriate, depending on your needs. Again, it's up to you to experiment!
 
-<video autoplay loop muted playsinline>
+<video aria-label="Exponentially weighted moving average filter output for three alpha values: 0.5 (red) tracking the raw signal closely, 0.1 (green), and 0.01 (yellow) heavily distorted and lagged" autoplay loop muted playsinline>
   <source src="assets/videos/ExponentialMovingAverageFilter-ThreeAlphaValues-Optimized.mp4" type="video/mp4" />
 </video>
 **Video** This video shows EWMA performance with $$\alpha$$ equal to 0.5 (red line), 0.1 (green line), and 0.01 (yellow line). The code used to produce this video is [here](https://github.com/makeabilitylab/arduino/blob/master/Filters/EwmaFilterAlphaDemo/EwmaFilterAlphaDemo.ino). Graph made with the built-in [Arduino Serial Plotter](https://diyrobocars.com/2020/05/04/arduino-serial-plotter-the-missing-manual/).
@@ -264,7 +264,7 @@ void loop()
 
 A **moving median filter** is almost the exact same as a [moving average filter](#moving-average-filter) but takes the **median** over the sliding window rather than the average. 
 
-<video autoplay loop muted playsinline>
+<video aria-label="An animation illustrating a moving median filter with a window size of three sliding over a signal to produce the smoothed output" autoplay loop muted playsinline>
   <source src="assets/videos/MovingMedianFilter_PowerPointAnimation_TrimmedAndCropped.mp4" type="video/mp4" />
 </video>
 **Video** This video shows a moving median filter with a window size of three. Animation made in PowerPoint.
@@ -295,7 +295,7 @@ But how can we obtain this "middle" value efficiently? We know that re-sorting a
 
 Similar to the moving average filter, we can tweak the moving median filter's performance by modifying the filter window size. Below, we show a moving median filter with window sizes 5, 11, and 21. For this video, we used our test code [MovingMedianFilterWindowSizeDemo.ino](https://github.com/makeabilitylab/arduino/blob/master/Filters/MovingMedianFilterWindowSizeDemo/MovingMedianFilterWindowSizeDemo.ino), which relies on Luis Llama's [Arduino Median Filter 2](https://github.com/warhog/Arduino-MedianFilter) library based on Phil Ekstrom's "[Better Than Average](https://www.embedded.com/better-than-average/)" article.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Moving median filter output for window sizes 5, 11, and 21, showing how the median filter flattens peaks in the signal, graphed in the Arduino Serial Plotter" autoplay loop muted playsinline>
   <source src="assets/videos/MovingMedianFilter-ThreeWindowSizes-TrimmedAndOptimized.mp4" type="video/mp4" />
 </video>
 **Video** This video shows moving median filter performance with window sizes 5, 11, and 21. Notice how a median filter tends to flatten "peaks" in the signal, which is unlike the other filters we've examined. To make this video, we used [this code](https://github.com/makeabilitylab/arduino/blob/master/Filters/MovingMedianFilterWindowSizeDemo/MovingMedianFilterWindowSizeDemo.ino) and the built-in [Arduino Serial Plotter](https://diyrobocars.com/2020/05/04/arduino-serial-plotter-the-missing-manual/).
@@ -305,7 +305,7 @@ Similar to the moving average filter, we can tweak the moving median filter's pe
 
 Median filters are widely used in image processing to remove noise from images (image processing is its own subfield of signal processing focusing on 2D DSP techniques). Unlike mean (or average) filters, median filters remove noise while preserving edges—and edges are often a crucial part of other image processing algorithms like the [Canny edge detector](https://en.wikipedia.org/wiki/Canny_edge_detector).
 
-![](assets/images/Medianfilterp_Wikipedia.png)
+![A noisy image with salt-and-pepper speckle on the left and the same image after median filtering removes the noise while preserving edges on the right](assets/images/Medianfilterp_Wikipedia.png)
 {: .mx-auto .align-center }
 
 **Figure**. Median filtering is widely used in image processing where it is particularly effective at removing "speckle" or "salt-and-pepper" noise while preserving edges. Image from [Wikipedia](https://en.wikipedia.org/wiki/Median_filter).
@@ -315,7 +315,7 @@ In the case of 1-dimensional signal processing, which we've focused on in this l
 
 | Moving Average Filter | Moving Median Filter |
 |:----------------:|:-------------:|
-| ![](assets/images/SignalSmoothingExample_13-OriginalMovingAverageAndSavitzkyGolay_MathWorks.png) |  ![](assets/images/SignalSmoothingExample_14-OriginalVsMedianFilter.png)  |
+| ![Graph of a clock signal whose sharp rising and falling edges are distorted and rounded by a moving average filter](assets/images/SignalSmoothingExample_13-OriginalMovingAverageAndSavitzkyGolay_MathWorks.png) |  ![Graph of a clock signal smoothed by a median filter that preserves and crispens the sharp transition edges](assets/images/SignalSmoothingExample_14-OriginalVsMedianFilter.png)  |
 | The moving average filter distorts the rising and falling edges of the clock signal | The median filter both smooths the signal and crispens the clock transition edges |
 
 **Figure.** Images from [MathWorks](https://www.mathworks.com/help/signal/ug/signal-smoothing.html).

--- a/arduino/led-blink3.md
+++ b/arduino/led-blink3.md
@@ -211,7 +211,7 @@ This [source code](https://github.com/makeabilitylab/arduino/blob/master/Basics/
 #### Workbench video
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/8DHhmXr3mC8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench video of an Arduino blinking multiple LEDs at different rates without using delay()" src="https://www.youtube.com/embed/8DHhmXr3mC8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ### Multi-rate blinking: an object-oriented approach
@@ -326,7 +326,7 @@ See the [code in our GitHub repository](https://github.com/makeabilitylab/arduin
 #### Workbench video
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/vb5l8Tncedo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench video of multi-rate LED blinking using the Blinker class in external .h and .cpp files" src="https://www.youtube.com/embed/vb5l8Tncedo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Exercises

--- a/arduino/rgb-led-fade.md
+++ b/arduino/rgb-led-fade.md
@@ -147,13 +147,13 @@ This [source code](https://github.com/makeabilitylab/arduino/blob/master/Basics/
 Here are two videos showing the code running on an Arduino Uno. First, in the Tinkercad simulator. You can see the crossfade colors and a plot of the corresponding `analogWrite` values.
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/ZyfHRQFwmeg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Tinkercad simulation of the RGB crossfader code with a plot of the corresponding analogWrite values" src="https://www.youtube.com/embed/ZyfHRQFwmeg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 Second, a workbench video of the code running on an Arduino Uno:
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/zL7xIWHqVaY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench video of the RGB crossfader code running on an Arduino Uno" src="https://www.youtube.com/embed/zL7xIWHqVaY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <!--TODO: add in a p5js that demonstrates how this works? And maybe let's reader play with different color values? -->
@@ -169,7 +169,7 @@ RGB and HSL color space visualizations from [Wikipedia](https://en.wikipedia.org
 Here's a video of various hues, saturations, and lightness levels using Hunor Marton's HSL Color Picker. Play around with it yourself on [codepen.io](https://codepen.io/HunorMarton/pen/dvXVvQ/). You can also open up almost any painting or graphics application to play with and switch between colorspaces from MSPaint to Adobe Photoshop and Illustrator to [GIMP](https://www.gimp.org/) and [Inkscape](https://inkscape.org/).
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/a0j8qyBJE2E" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Screen recording of Hunor Marton's HSL Color Picker showing various hues, saturations, and lightness levels" src="https://www.youtube.com/embed/a0j8qyBJE2E" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 A screen recording of [Hunor Marton's HSL Color Picker](https://codepen.io/HunorMarton/pen/dvXVvQ/).
 {: .fs-1 }
@@ -225,7 +225,7 @@ This [source code](https://github.com/makeabilitylab/arduino/blob/master/Basics/
 Here's a workbench video of [CrossFadeHue.ino](https://github.com/makeabilitylab/arduino/tree/master/Basics/analogWrite/CrossFadeHue) with a common cathode RGB LED.
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/ROfJge7bsfI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench video of the HSL-based RGB crossfader (CrossFadeHue.ino) running on a common cathode RGB LED" src="https://www.youtube.com/embed/ROfJge7bsfI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <!-- TODO look up what the minimum step value that makes sense with our quantization -->

--- a/arduino/rgb-led.md
+++ b/arduino/rgb-led.md
@@ -185,14 +185,14 @@ That's it. Now compile, upload, and run your code!
 In the video below, I'm running our [BlinkRGB](https://github.com/makeabilitylab/arduino/tree/master/Basics/digitalWrite/BlinkRGB) code, which is the same as above but includes some [`Serial.print`](https://www.arduino.cc/reference/en/language/functions/communication/serial/print/) calls for debugging (see this [mini-tutorial](https://create.arduino.cc/projecthub/glowascii/serial-monitor-arduino-basics-399eb6) on using the Serial.print and the Arduino IDE's Serial Monitor for debugging)
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/ASez28rPjRU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench video of the BlinkRGB code cycling a common cathode RGB LED through colors, diffused by a yogurt container" src="https://www.youtube.com/embed/ASez28rPjRU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 The yogurt container is used to diffuse the light. Kleenex, white paper, or a ping pong ball (with a hole in it for the LED) works well too!
 {: .fs-1 }
 
 Below, we show a video animation of the code executing and resulting circuit behavior. Pay close attention to the direction of current—it will flow in the opposite direction with the Common Anode design (covered next).
 
-<video controls="controls">
+<video aria-label="Animation of a common cathode RGB LED circuit executing, showing the direction of current flow" controls="controls">
   <source src="assets/movies/Arduino_RGBLED_CommonCathode_Animation.mp4" type="video/mp4">
 </video>
 
@@ -249,7 +249,7 @@ We will flash the same sequence as before but again our `HIGH`s and `LOW`s are f
 
 Here's an animation. Pay close attention to the current direction—it flows from 5V down through the LED, the current limiting resistors, and into the digital I/O pins.
 
-<video controls="controls">
+<video aria-label="Animation of a common anode RGB LED circuit with current flowing from 5V down through the LED and resistors into the digital I/O pins" controls="controls">
   <source src="assets/movies/Arduino_RGBLED_CommonAnode_Animation.mp4" type="video/mp4">
 </video>
 

--- a/cpx/analog-input.md
+++ b/cpx/analog-input.md
@@ -71,19 +71,19 @@ In the above examples, we showed how to read 3.3V and GND (0V) with the CPX by t
 
 We can do this by dividing the input voltage using resistors, which we cover in great detail in our [Electronics L4: Voltage Divider lesson](series-parallel.md#voltage-dividers) and touch on it a bit in the above video. We need not repeat ourselves here; however, if you want to experiment with manually controlling different input voltages on A1, try adding different resistor combinations like the following.
 
-![](assets/images/CPX_IntroToVoltageDivider.png)
+![Intro to using a voltage divider with two resistors to control the input voltage on CPX pin A1](assets/images/CPX_IntroToVoltageDivider.png)
 
 The key is not the raw resistor values themselves but rather the ratio between them. With equal resistors—in this case 330Ω—the 3.3V will be divided equally to 1.65V (and converted to 512 by the CPX).
 
-![](assets/images/CPX_VoltageDividerEqual330Ohm.png)
+![Voltage divider on the CPX with two equal 330-ohm resistors splitting 3.3V to 1.65V on A1](assets/images/CPX_VoltageDividerEqual330Ohm.png)
 
 Similarly, if we add a pair of 470 resistors, the 3.3V will again be divided equally to 1.65V (and again converted to 512 by the CPX)
 
-![](assets/images/CPX_VoltageDividerEqual470Ohm.png)
+![Voltage divider on the CPX with two equal 470-ohm resistors splitting 3.3V to 1.65V on A1](assets/images/CPX_VoltageDividerEqual470Ohm.png)
 
 But if we change that ratio, we can get different input voltages on A1.
 
-![](assets/images/CPX_VoltageDivider1kAnd2kResistors.png)
+![Voltage divider on the CPX with unequal 1k and 2k resistors producing a different input voltage on A1](assets/images/CPX_VoltageDivider1kAnd2kResistors.png)
 
 <!-- Well, the answer is: sensors vary their output voltages to convey data to microcontrollers. One common class of sensors is called "resistive sensors" such as potentiometers, pressure sensors, thermistors, and more, which vary their resistance based on some human or environmental interaction. -->
 
@@ -105,33 +105,33 @@ You can test any of these circuits using [this basic MakeCode](https://makecode.
 
 Hooking up a rotary potentiometer
 
-![](assets/images/CPX_RotaryPotentiometer_CircuitDiagram.png)
+![Circuit diagram for wiring a single rotary potentiometer to analog pin A1 on the CPX](assets/images/CPX_RotaryPotentiometer_CircuitDiagram.png)
 
 Hooking up two rotary potentiometers ([try out this code!](https://makecode.com/_CLJ8U8F2d7sT)):
 
-![](assets/images/CPX_2RotaryPotentiometers_CircuitDiagram.png)
+![Circuit diagram for wiring two rotary potentiometers to analog pins A1 and A2 on the CPX](assets/images/CPX_2RotaryPotentiometers_CircuitDiagram.png)
 
 #### Slide Potentiometer
 
-![](assets/images/CPX_SlidePotentiometer_CircuitDiagram.png)
+![Circuit diagram for wiring a slide potentiometer to analog pin A1 on the CPX](assets/images/CPX_SlidePotentiometer_CircuitDiagram.png)
 
 #### Pressure Sensor
 
 You might be compelled to hook up your two-legged resistive sensors like pressure sensors, flex sensors, photosensitive resistors like this... but don't do this! It's wrong!
 
-![](assets/images/CPX_PressureSensor_IncorrectCircuitDiagram.png)
+![Incorrect circuit diagram wiring a two-legged pressure sensor directly to A1 without a divider resistor](assets/images/CPX_PressureSensor_IncorrectCircuitDiagram.png)
 
 Instead, you need to add in an additional resistor to turn the circuit into a voltage divider where one of the resistors is your sensor, which dynamically changes its resistance.
 
-![](assets/images/CPX_PressureSensor_CircuitDiagram.png)
+![Correct circuit diagram wiring a pressure sensor with a fixed resistor as a voltage divider into A1](assets/images/CPX_PressureSensor_CircuitDiagram.png)
 
 #### Photosensitive Resistor
 
-![](assets/images/CPX_PhotosensitiveResistor_CircuitDiagram.png)
+![Circuit diagram wiring a photosensitive resistor with a fixed resistor as a voltage divider into A1](assets/images/CPX_PhotosensitiveResistor_CircuitDiagram.png)
 
 #### Flex Sensor
 
-![](assets/images/CPX_FlexSensor_CircuitDiagram.png)
+![Circuit diagram wiring a flex sensor with a fixed resistor as a voltage divider into A1 on the CPX](assets/images/CPX_FlexSensor_CircuitDiagram.png)
 
 ### Code
 

--- a/cpx/cpx.md
+++ b/cpx/cpx.md
@@ -56,7 +56,7 @@ It's OK if you don't understand all of the terminology used below. In fact, if t
 
 ### Built-in Input
 
-<video autoplay loop muted playsinline>
+<video aria-label="Using the CPX's on-board accelerometer as a motion mouse to paint on a computer screen" autoplay loop muted playsinline>
   <source src="assets/videos/CPX_PaintingWithCPXAccelerometerAsAMouse.mp4" type="video/mp4" />
 </video>
 
@@ -126,7 +126,7 @@ Each pad can provide up to ~20mA of current so **do not connect a motor** or oth
 For more information, see [Adafruit's CPX Pinouts Guide](https://learn.adafruit.com/adafruit-circuit-playground-express/pinouts#each-pin-2906289).
 
 ### Analog Input
-<video autoplay loop muted playsinline>
+<video aria-label="Reading a potentiometer as analog input on the CPX, changing values as the knob is turned" autoplay loop muted playsinline>
   <source src="assets/videos/CPX_AnalogInput_PotentiometerOverview_Optimized.mp4" type="video/mp4" />
 </video>
 
@@ -143,7 +143,7 @@ You'll learn more about analog input in [L8: Analog Input](analog-input.md)!
 
 ### Capacitive Touch Sensor Pads
 
-<video autoplay loop muted playsinline>
+<video aria-label="Using the CPX with a soda can and capacitive touch sensing to build a hand proximity detector" autoplay loop muted playsinline>
   <source src="assets/videos/CPX_CapacitiveSensing_SodaCanProximityDetector_MakeCode_Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** Pins A1-A7 on the CPX can be used for capacitive touch sensing. Here, I'm showing how we can use a soda can to build a simple hand proximity detector. [Learn more here!](capacitive-touch.md)
@@ -172,7 +172,7 @@ The CPX also has a powerful embedded microcontroller—the ATSAMD21 ARM Cortex M
 
 ## Using the CPX as Computer Input
 
-<video playsinline controls>
+<video aria-label="Playing a banana piano made with the CPX acting as a capacitive-touch keyboard input to a computer" playsinline controls>
   <source src="assets/videos/CPX_BananaPiano_OptimizedTrimmed.mp4" type="video/mp4" />
 </video>
 **Video.** The CPX can be used as an input controller to your computer. You can make your own keyboard, mouse, joystick, and more! This example is from [Lesson 5.3: Making a Capacitive Keyboard](capacitive-touch.md#lesson-53-making-a-capacitive-touch-keyboard).
@@ -207,7 +207,7 @@ This is the old Adafruit video we used to have here
     Your browser does not support the video tag.
 </video> -->
 
-<video autoplay loop muted playsinline>
+<video aria-label="Rapidly building the Blinky program in MakeCode that flashes all the CPX NeoPixels red on and off" autoplay loop muted playsinline>
   <source src="assets/videos/Making_Blinky_MakeCode_Annotated.mp4" type="video/mp4" />
 </video>
 **Video.** Rapidly creating a full program with MakeCode called "Blinky." We will turn on all the NeoPixels (by setting them red) then pause then turn them off (by setting them black) and repeat "forever." [Code link](https://makecode.com/_JdPfj8VrmWV3).

--- a/cpx/digital-input.md
+++ b/cpx/digital-input.md
@@ -42,7 +42,7 @@ If you want to skip all the theory about why pull-down resistors and just "follo
 
 ### Circuit Diagrams
 
-![](assets/images/CPX_ExternalPullDownAndPullUpResistors.png)
+![Circuit diagrams showing a button wired with an external pull-down resistor and with an external pull-up resistor on the CPX](assets/images/CPX_ExternalPullDownAndPullUpResistors.png)
 
 ### Code
 
@@ -60,9 +60,9 @@ In this video, we introduce external pull-up resistors and then using internal p
 
 ### Circuit Diagrams
 
-![](assets/images/CPX_InternalPullUpResistorConfiguration.png)
+![Circuit diagram for a button using the CPX's internal pull-up resistor configuration](assets/images/CPX_InternalPullUpResistorConfiguration.png)
 
-![](assets/images/CPX_InternalPullDownResistorConfiguration.png)
+![Circuit diagram for a button using the CPX's internal pull-down resistor configuration](assets/images/CPX_InternalPullDownResistorConfiguration.png)
 
 ## Lesson 8.4: Hooking up Arcade Buttons to the CPX
 
@@ -76,15 +76,15 @@ In this video, we show how to hook up arcade buttons to the CPX, which have cool
 
 Using an external pull-down resistor with the arcade button.
 
-![](assets/images/CPX_ArcadeButtonExternalPullDown.png)
+![Circuit diagram wiring an arcade button to the CPX using an external pull-down resistor](assets/images/CPX_ArcadeButtonExternalPullDown.png)
 
 Using an internal pull-down resistor with the arcade button (but not hooking up the internal LED).
 
-![](assets/images/CPX_ArcadeButtonInternalPullDown.png)
+![Circuit diagram wiring an arcade button to the CPX using an internal pull-down resistor, without the embedded LED](assets/images/CPX_ArcadeButtonInternalPullDown.png)
 
 Hooking up internal LED. Here's [example code](https://makecode.com/_0oVYVmYK5gYt) that turns on the internal LED when the button is pressed.
 
-![](assets/images/CPX_ArcadeButtonInternalPullDown_WithInternalLED.png)
+![Circuit diagram wiring an arcade button with its embedded LED to the CPX using an internal pull-down resistor](assets/images/CPX_ArcadeButtonInternalPullDown_WithInternalLED.png)
 
 <!-- TODO: add in circuit diagrams and code links 
 Post advance code for debouncing

--- a/cpx/index.md
+++ b/cpx/index.md
@@ -20,7 +20,7 @@ nav_order: 5
 {:toc}
 ---
 
-<video autoplay loop muted playsinline>
+<video aria-label="Using the CPX and capacitive sensing to measure a hand's distance from a soda can as a proximity detector" autoplay loop muted playsinline>
   <source src="assets/videos/CPX_CapacitiveSensing_SodaCanProximityDetector_MakeCode_Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** In the video above, we are using the CPX and capacitive sensing to measure the hand's distance from the soda can. See more in [Lesson 5: Capacitive Sensing](capacitive-touch.md). Join us in this tutorial series to learn about the amazing [Circuit Playground Express (CPX)](https://www.adafruit.com/product/3333) microcontroller platform and drag-and-drop visual programming called [MakeCode](https://www.microsoft.com/en-us/makecode).

--- a/cpx/makecode.md
+++ b/cpx/makecode.md
@@ -23,7 +23,7 @@ In this lesson, we will make our first MakeCode+CPX program—called Blinky—wh
 
 ## The MakeCode Programming Environment
 
-<video autoplay loop muted playsinline>
+<video aria-label="Rapidly building a simple rainbow NeoPixel animation program by dragging blocks in MakeCode" autoplay loop muted playsinline>
   <source src="assets/videos/Making_SimpleFastAnimationProgram_MakeCode_ScreenRecording.mp4" type="video/mp4" />
 </video>
 **Video.** Rapidly creating a full program with MakeCode: a simple rainbow animation. [Code link](https://makecode.com/_8uY3D8Fc8A5t).
@@ -35,7 +35,7 @@ MakeCode is a visual programming language—like [Scratch](https://scratch.mit.e
 
 ### The MakeCode interface
 
-![](assets/images/MakeCode_ProgrammingInterface.png)
+![Annotated MakeCode editor with the workspace, toolbox, and simulator areas numbered](assets/images/MakeCode_ProgrammingInterface.png)
 **Figure.** An annotated screenshot of the MakeCode interface highlighting the (1) programming workspace, (2) toolbox, and (3) the simulator.
 {: .fs-1 }
 
@@ -49,7 +49,7 @@ The MakeCode editor has three primary user interface areas: (1) programming work
 
 Let's make our first program: Blinky! To start, we'll make Blinky flash all ten of the CPX's NeoPixel LEDs on and off. Then we'll add in a special "startup" sound to introduce other programmable elements.
 
-<video autoplay loop muted playsinline>
+<video aria-label="The Blinky program running in the MakeCode simulator with NeoPixels flashing red for 500ms then off" autoplay loop muted playsinline>
   <source src="assets/videos/Making_Blinky_MakeCode_FinalLoop.mp4" type="video/mp4" />
 </video>
 **Video.** The initial Blinky program: notice how the simulator's lights (the NeoPixels) are flashing red for 500ms then off for 500ms and repeating.
@@ -61,13 +61,13 @@ As you build your program, observe how the simulator on the left shows it's beha
 
 To start, go to [https://makecode.adafruit.com/](https://makecode.adafruit.com) and click the "New Project" button.
 
-![](assets/images/MakingBlinky_StartingANewProject.png)
+![The MakeCode website home page with the New Project button highlighted](assets/images/MakingBlinky_StartingANewProject.png)
 **Figure.** On the [MakeCode website](https://makecode.adafruit.com), click the "New Project" button.
 {: .fs-1 }
 
 After clicking, you should see the MakeCode editor interface with a largely empty workspace (see screenshot below). You might observe that MakeCode pre-populates the workspace with a [`forever`](https://makecode.adafruit.com/reference/loops/forever) block, which starts automatically and runs repeatedly in a loop *forever.*
 
-![](assets/images/MakingBlinky_TheForeverBlock.png)
+![A new MakeCode workspace pre-populated with an empty forever loop block](assets/images/MakingBlinky_TheForeverBlock.png)
 **Figure.** The [`forever`](https://makecode.adafruit.com/reference/loops/forever) block starts automatically and runs repeatedly in a loop *forever.* Remember, you can always right click on these images and select "Open image in new tab" to see larger versions.
 {: .fs-1 }
 
@@ -79,13 +79,13 @@ Now let's add our first block: a [`LIGHT`](https://makecode.adafruit.com/referen
 
 From the [`LIGHT`](https://makecode.adafruit.com/reference/light) menu inside the toolbox, drag-and-drop the [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block to the workspace. 
 
-![](assets/images/MakingBlinky_TheFirstLightBlock.png)
+![Dragging the set all pixels to block out of the LIGHT toolbox menu in MakeCode](assets/images/MakingBlinky_TheFirstLightBlock.png)
 **Figure.** Drag-and-drop the [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block from the [`LIGHT`](https://makecode.adafruit.com/reference/light) menu.
 {: .fs-1 }
 
 Place the [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block inside the [`forever`](https://makecode.adafruit.com/reference/loops/forever) block in the workspace. Your program should now look like this:
 
-![](assets/images/MakingBlinky_TheSetAllPixelsToBlock.png)
+![The set all pixels to red block placed inside the forever block, with the simulator NeoPixels glowing red](assets/images/MakingBlinky_TheSetAllPixelsToBlock.png)
 **Figure.** The [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block sets all 10 CPX lights (the NeoPixels) to the same color. In this case, we'll set them to red.
 {: .fs-1 }
 
@@ -95,13 +95,13 @@ Notice too how the NeoPixels are now glowing red in the simulator—neat!
 
 To make the light **blink**, we need to add in a [`pause`](https://makecode.adafruit.com/reference/loops/pause) block, which is somewhat hidden away in the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) toolbox menu. Click on the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) menu button and drag-and-drop the [`pause`](https://makecode.adafruit.com/reference/loops/pause) block to the workspace.
 
-![](assets/images/MakingBlinky_AddingTheFirstPauseBlock.png)
+![Dragging the pause block out of the LOOPS toolbox menu in MakeCode](assets/images/MakingBlinky_AddingTheFirstPauseBlock.png)
 **Figure.** Drag-and-drop the [`pause`](https://makecode.adafruit.com/reference/loops/pause) block from the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) toolbox menu.
 {: .fs-1 }
 
 Let's set the red light to stay on for half-a-second (500 milliseconds) before moving on to the next puzzle piece.
 
-![](assets/images/MakingBlinky_DescribingThePauseBlock.png)
+![A pause block set to 500 milliseconds added after the red light block in the Blinky program](assets/images/MakingBlinky_DescribingThePauseBlock.png)
 **Figure.** The [`pause`](https://makecode.adafruit.com/reference/loops/pause) block pauses your program for a specified time. In this case, let's set it to half-a-second (500ms) so that the red light is shown for 500ms.
 {: .fs-1 }
 
@@ -109,26 +109,26 @@ Let's set the red light to stay on for half-a-second (500 milliseconds) before m
 
 Finally, to complete the blinking effect, we need to turn off the lights. Again, we can use the [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block.
 
-![](assets/images/MakingBlinky_AddingSecondLightBlock.png)
+![Dragging a second set all pixels to block from the LIGHT menu to turn the lights off](assets/images/MakingBlinky_AddingSecondLightBlock.png)
 **Figure.** To turn off the light, we need another light block. Drag-and-drop a second [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block from the [`LIGHT`](https://makecode.adafruit.com/reference/light) menu.
 {: .fs-1 }
 
 This time we will set the light color to black. In MakeCode, setting lights to black is equivalent to turning them off. You could choose a different color, if you'd like.
 
-![](assets/images/MakingBlinky_SettingSecondLightBlockToBlack.png)
+![Choosing black from the color pop-up menu in the second set all pixels to block to turn the lights off](assets/images/MakingBlinky_SettingSecondLightBlockToBlack.png)
 **Figure.** To change the light colors in the [`set all pixels to`](https://makecode.adafruit.com/reference/light/set-all) block, click on the colored oval and select a color from the pop-up menu.
 {: .fs-1 }
 
 ### Step 5: Add final pause block
 As before, we also need to add in a [`pause`](https://makecode.adafruit.com/reference/loops/pause) block, which will control how long the lights are off before looping back to the beginning of our program.
 
-![](assets/images/MakingBlinky_AddingFinalPauseBlock.png)
+![Dragging a second pause block from the LOOPS menu to keep the lights off before the loop repeats](assets/images/MakingBlinky_AddingFinalPauseBlock.png)
 **Figure.** Drag-and-drop the [`pause`](https://makecode.adafruit.com/reference/loops/pause) block from the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) toolbox menu.
 {: .fs-1 }
 
 Our final program should look like this. Because our code sits within a [`forever`](https://makecode.adafruit.com/reference/loops/forever) block, it will loop forever thereby creating a neverending on-off flashing of red lights.
 
-![](assets/images/MakingBlinky_LoopingBackToTheBeginning.png)
+![The completed Blinky program: two light blocks and two pauses nested inside the forever loop](assets/images/MakingBlinky_LoopingBackToTheBeginning.png)
 **Figure.** Because our code sits within a [`forever`](https://makecode.adafruit.com/reference/loops/forever) block, it will loop forever thereby creating a neverending on-off flashing of red lights.
 {: .fs-1 }
 
@@ -136,7 +136,7 @@ Our final program should look like this. Because our code sits within a [`foreve
 
 Here's a full walkthrough video of building Blinky from start-to-finish in MakeCode in only 30 seconds. This really demonstrates how quickly we can prototype electronic behaviors with MakeCode+CPX.
 
-<video autoplay loop muted playsinline>
+<video aria-label="A 30-second full walkthrough of building the Blinky program from start to finish in MakeCode" autoplay loop muted playsinline>
   <source src="assets/videos/Making_Blinky_MakeCode_ScreenRecording.mp4" type="video/mp4" />
 </video>
 **Video.** A full walkthrough video of building Blinky from start-to-finish in only 30 seconds. Feel free to pause the video or open it in a new tab for full screen (right click on the video and select "Open video in new tab").
@@ -146,7 +146,7 @@ Here's a full walkthrough video of building Blinky from start-to-finish in MakeC
 
 Before downloading Blinky on to the physical CPX board, let's make one more addition: a "startup" sound, which plays when the CPX is first turned on (or reset).
 
-<video autoplay loop muted playsinline>
+<video aria-label="Adding a power-up startup sound to the Blinky program in MakeCode" autoplay loop muted playsinline>
   <source src="assets/videos/Making_BlinkyWithPowerUp_ScreenRecording.mp4" type="video/mp4" />
 </video>
 **Video.** Adding a "startup" sound to Blinky. Now, when Blinky is turned on, it will play a sound.
@@ -158,13 +158,13 @@ In addition to the [`forever`](https://makecode.adafruit.com/reference/loops/for
 
 Open the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) toolbox menu and drag-and-drop the [`on start`](https://makecode.adafruit.com/blocks/on-start) block into your workspace.
 
-![](assets/images/MakingBlinkyWithSound_AddingInOnStart.png)
+![Dragging the on start block from the LOOPS toolbox menu into the MakeCode workspace](assets/images/MakingBlinkyWithSound_AddingInOnStart.png)
 **Figure.** Drag-and-drop the [`on start`](https://makecode.adafruit.com/blocks/on-start) block from the [`LOOPS`](https://makecode.adafruit.com/blocks/loops) toolbox menu.
 {: .fs-1 }
 
 Now your Blinky program should look like this. I've arbitrarily placed the [`on start`](https://makecode.adafruit.com/blocks/on-start) block next to the [`forever`](https://makecode.adafruit.com/blocks/on-start) block—you can put it wherever you want. Regardless of its position in the editor, the [`on start`](https://makecode.adafruit.com/blocks/on-start) block will always run before the [`forever`](https://makecode.adafruit.com/blocks/on-start) block.
 
-![](assets/images/MakingBlinkyWithSound_OnStartDescription.png)
+![The Blinky workspace showing an empty on start block placed beside the forever block](assets/images/MakingBlinkyWithSound_OnStartDescription.png)
 **Figure.** The [`on start`](https://makecode.adafruit.com/blocks/on-start) block runs automatically when the program first starts.
 {: .fs-1 }
 
@@ -174,13 +174,13 @@ Thus far, we have only programmed one type of output, [light](https://makecode.a
 
 Let's use the [`play sound`](https://makecode.adafruit.com/reference/music/play-sound) block, which plays a preprogrammed sound like "power up" or "jump up" (these sounds may be familiar to you as some come from Super Mario!).
 
-![](assets/images/MakingBlinkyWithSound_TheMusicMenu.png)
+![Dragging the play sound block from the MUSIC toolbox menu in MakeCode](assets/images/MakingBlinkyWithSound_TheMusicMenu.png)
 **Figure.** Drag-and-drop the [`play sound`](https://makecode.adafruit.com/reference/music/play-sound) block from the [`MUSIC`](https://makecode.adafruit.com/reference/music) toolbox menu.
 {: .fs-1 }
 
 You are welcome to select any sound option. We're going to use "power up." As soon as you add this block, you should hear the sound play in the simulator (assuming your sound is on and you have speakers/headphones).
 
-![](assets/images/MakingBlinkyWithSound_ThePlaySoundBlock.png)
+![The play sound block set to power up placed inside the on start block](assets/images/MakingBlinkyWithSound_ThePlaySoundBlock.png)
 **Figure.** The [`play sound`](https://makecode.adafruit.com/reference/music/play-sound) block plays the selected sound.
 {: .fs-1 }
 
@@ -188,7 +188,7 @@ You are welcome to select any sound option. We're going to use "power up." As so
 
 You did it! The final program should look like this:
 
-![](assets/images/MakingBlinkyWithSound_TheFinalProgram.png)
+![The finished Blinky with Sound program showing the on start sound block and the forever blinking loop](assets/images/MakingBlinkyWithSound_TheFinalProgram.png)
 **Figure.** The final ["Blinky with Sound" program](https://makecode.com/_2iL2xkVKa7Dh) in MakeCode. You can edit and play with our code [here](https://makecode.com/_2iL2xkVKa7Dh)—we changed the color from red to blue. 
 {: .fs-1 }
 
@@ -207,7 +207,7 @@ We'll cover both below. We recommend at least trying the "direct download" appro
 
 ### Manual download
 
-<video autoplay loop muted playsinline>
+<video aria-label="Downloading a MakeCode program and copying the .uf2 file onto the CPX using a Mac" autoplay loop muted playsinline>
   <source src="assets/videos/CopyingProgramToCPXFromMac_NoSound.mp4" type="video/mp4" />
 </video>
 **Video.** Downloading a MakeCode program and transferring it to the CPX using a Mac.
@@ -220,7 +220,7 @@ Manually downloading your MakeCode program to the CPX is a 4-step process:
 3. **Put CPX into programmable state.** Click the 'Reset' button on the CPX. The CPX should glow green and mount a new "thumb drive" folder called CPLAYBOOT; 
 4. **Move .uf2 file onto CPLAYBOOT** Drag-and-drop the downloaded `.uf2` file onto CPLAYBOOT. When the file finishes copying, the CPX will auto-reset and begin running your program—which will also disconnect the CPX from your laptop/computer.
 
-![](assets/images/ThreeStepProcessForManuallyProgrammingCPX.png)
+![The MakeCode three-stage prompt for downloading the .uf2 file and copying it onto the CPX](assets/images/ThreeStepProcessForManuallyProgrammingCPX.png)
 
 **Figure.** After you click the pink 'Download' button in MakeCode, the MakeCode interface shows this three-stage prompt for transferring the downloaded `.uf2` file to the CPX.
 {: .fs-1 }
@@ -229,7 +229,7 @@ We will show you how to do this for both Windows and Mac.
 
 #### Manual download with Mac
 
-<video playsinline controls>
+<video aria-label="Walkthrough of downloading a MakeCode program and transferring it to the CPX on a Mac" playsinline controls>
   <source src="assets/videos/CopyingProgramToCPXFromMac.mp4" type="video/mp4" />
 </video>
 **Video.** Downloading a MakeCode program and transferring it to the CPX using a Mac.
@@ -259,7 +259,7 @@ In this video, we walk you through how to directly download your MakeCode progra
 
 If you want to share your program with others, click on the Share button in the navbar and copy/paste the provided URL. See the video below.
 
-<video loop muted playsinline controls>
+<video aria-label="Sharing a MakeCode program by clicking the Share button and copying the generated URL" loop muted playsinline controls>
   <source src="assets/videos/MakeCode_SharingYourProject2.mp4" type="video/mp4" />
 </video>
 **Video.** To share your MakeCode program with others, click on the Share button in the navbar and copy/paste the url link. [Code link](https://makecode.com/_JdPfj8VrmWV3).
@@ -271,7 +271,7 @@ We did it! We successfully built our first program in MakeCode, ran it in the si
 
 For this lesson's design challenge, try seeing how many different ways you can build interesting light patterns with MakeCode using commands such show animation, photon, and more! Below, we've included a simple example but you can do so much more!
 
-<video autoplay loop muted playsinline>
+<video aria-label="A playground of different built-in NeoPixel animations running in MakeCode on the CPX" autoplay loop muted playsinline>
   <source src="assets/videos/MakeCode_SimpleNeoPixelFun_Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** A very simple playground of different NeoPixel animations built in to MakeCode [Code link](https://makecode.com/_AxFigA8KX82K). We are also using console out commands to help us reference the various animations.

--- a/electronics/leds.md
+++ b/electronics/leds.md
@@ -44,7 +44,7 @@ So, while LEDs are now pervasive, they're relatively new technology with active 
 
 To better understand light-emitting diodes, it's first useful to learn a bit about regular **diodes** and how to use them. As noted, diodes are a special type of [semiconductor device](https://en.wikipedia.org/wiki/Semiconductor_device) that, ideally, conduct current in **only one direction**. See animation below.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Circuit simulation showing current flowing through a diode from anode to cathode, then stopping when the diode's orientation is reversed" autoplay loop muted playsinline>
   <source src="assets/videos/DiodeOnlyWorksInOneDirection_CircuitJS_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 
@@ -148,7 +148,7 @@ Now that we know $$V_R=8.3V$$, we can use Ohm's Law to solve for the current $$I
 
 We can also use our trusty [CircuitJS](https://www.falstad.com/circuit/circuitjs.html) tool to simulate this circuit and check our answer. As the simulation shows below, our calculation of $$83mA$$ was spot on (even though we simplified the diode's true current-voltage operation).
 
-<video autoplay loop muted playsinline>
+<video aria-label="CircuitJS simulation of a basic resistor-diode circuit with a 9V battery, 100 ohm resistor, and 1N4001 diode, showing 83mA of current" autoplay loop muted playsinline>
   <source src="assets/videos/DiodeResistorCircuitBasic_CircuitJS_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 
@@ -372,7 +372,7 @@ We could, of course, also use our resistor equivalence rules to combine a resist
 
 We can also check our work in a circuit simulator like [CircuitJS](https://www.falstad.com/circuit/circuitjs.html), which is good practice in general before investing time in physically building something.
 
-<video autoplay loop muted playsinline>
+<video aria-label="CircuitJS simulation comparing three LED circuits using 330 ohm, 350 ohm, and 470 ohm current-limiting resistors" autoplay loop muted playsinline>
   <source src="assets/videos/ThreeLEDCircuitsWithDifferentCurrentLimitingResistors_CircuitJS.mp4" type="video/mp4" />
 </video>
 **Video.** This is a screen recording of the [CircuitJS](https://www.falstad.com/circuit/circuitjs.html) simulation of the 330Ω, 350Ω, and 470Ω LED-based circuits. Play with the circuit [here](https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACgA3EQm2ub3mEJURfEMSiSYCNgHcB4YXypCVbAE7LwGQlpQJdVbLjkKa-c1UvhT11VrA6QKW-327rKPHmeujCFC1PNgAPEGxeIgkEekxAwV1iADU2IXi3by1sAOcQABMGADMAQwBXABsAFyZyhjzwKShYdjTwGnNnTLB2-0DAgpKK6tr6iFEYSHYwsEgMSJJkYliMeMVxFPlujuzAvas3Uz3nAzaOrx8XTZ7FFWvHXUvwGd47a7sNU5UnI-dJGgxIIdnjdPiD2FxWJAXvxIQlxmIJONoDIAOZmfg8WhCKRsNGwhzAmjYkS4ijEdJUBDkrGGKCcMkUhkg0QdRFSZGmKm7JTknz2diaXnaRJeY607KA+RcrRC97yIX2BVOR5C36qzIq0U7cSi4JhAx9BYIPAQOK0NbJVKEQLqnxC7X9IplKo1OoNJGTNhAA) in CircuitJS.
@@ -396,7 +396,7 @@ No. A resistor limits the current *throughout* a circuit loop. We know this from
 
 Don't believe me? Try performing the same circuit analysis we stepped through above but with the LED before the resistor. What changes? Nothing, right? $$V_f$$ is still 2V and thus $$V_R$$ is still 7V. Here's a simulation demonstrating that nothing changes! 
 
-<video autoplay loop muted playsinline>
+<video aria-label="CircuitJS simulation showing that placing the 350 ohm current-limiting resistor before or after the LED produces identical behavior" autoplay loop muted playsinline>
   <source src="assets/videos/ResistorBeforeOrAfterTheLED_CircuitJS.mp4" type="video/mp4" />
 </video>
 **Video.** [CircuitJS](https://www.falstad.com/circuit/circuitjs.html) simulation of a LED-based circuit with the 350Ω current-limiting resistor either before or after the LED. Do you observe any differences? Play with the circuit [here](https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACgA3EQm2ub3mEJURfEMSiSYCNgHcB4YRRR5FVdgCdlqsBkLaQKBPvVw5CmvwQq+689Z1KH4PYfs2j+5ytUp3q7GsDSyo-AA9FXiIJMDwITF4aRXEANTYAEwMfA0CokHSGADMAQwBXABsAFzYgA).
@@ -408,7 +408,7 @@ In short: Heat. Possible spark or small fire. Burn out. Open circuit.
 
 There are lots of fun YouTube videos of supplying too much current to LEDs and observing the effect. Here's a snippet of a good one from [Afrotechmods](https://youtu.be/Yo6JI_bzUzo).
 
-<video autoplay loop muted playsinline>
+<video aria-label="An LED burning out when too much current is applied with no current-limiting resistor, exceeding its forward voltage" autoplay loop muted playsinline>
   <source src="assets/videos/LEDBurnOut_Afrotechmods_Trimmed.mp4" type="video/mp4" />
 </video>
 **Video.** This video shows what happens when the applied voltage significantly exceeds the LED's forward voltage $$V_f$$ with no current limiting resistor. Video from [Afrotechmods](https://youtu.be/Yo6JI_bzUzo).
@@ -428,7 +428,7 @@ For each circuit, first sketch out the idea on paper using a circuit schematic r
 
 To wire wrap your components, simply twist the legs together like this:
 
-<video autoplay loop muted playsinline>
+<video aria-label="Wire wrapping an LED by twisting the component legs together to make a connection" autoplay loop muted playsinline>
   <source src="assets/videos/WireWrapAnLED_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** An example of wire wrapping.
@@ -442,7 +442,7 @@ Here's an example picture of a simple LED circuit with alligator clips and wire 
 
 We'd also like you to begin experimenting with light diffusion and ideas for enclosures. For one of your LED designs, rapidly prototype a diffusive cover or case. As an example, here are simple light sabers my children and I made out of toilet paper rolls (for the hilt), paper (for the "plasma energy" blade), a 9V battery, a resistor, and some LEDs.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Light sabers made from toilet paper rolls, paper, a 9V battery, a resistor, and LEDs glowing in a simple LED circuit" autoplay loop muted playsinline>
   <source src="assets/videos/StarWars_SimpleToiletRollLightSabers_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** Example light sabers made out of toilet paper cardboard rolls, paper, and a simple LED circuit.

--- a/electronics/variable-resistors.md
+++ b/electronics/variable-resistors.md
@@ -50,7 +50,7 @@ Potentiometers are probably the most common type of variable resistor and an imp
 
 A [potentiometer](https://en.wikipedia.org/wiki/Potentiometer) (or pot) is a three-terminal resistor with a sliding or rotating contact that can be used to dynamically vary resistance.  
 
-<video autoplay loop muted playsinline>
+<video aria-label="Animation showing how the wiper varies resistance in a rotary potentiometer, alongside its electrical schematic symbol" autoplay loop muted playsinline>
   <source src="assets/videos/Potentiometer_Overview_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** This animation shows how the wiper can be used to vary resistance in a rotary potentiometer. The figure on the right is the formal electrical symbol. Animation by Jon Froehlich. Created in PowerPoint.
@@ -72,7 +72,7 @@ Potentiometers have three legs: the resistance between the outer two legs (Leg 1
 
 The power of a potentiometer is in that middle leg (Leg 2) whose resistance varies depending on the potentiometer's sliding or rotating contact (the wiper) position. It may help to think of a potentiometer as containing two interdependent resistors $$R_1$$ and $$R_2$$ that always sum to $$R_{Total}$$ (where $$R_{Total}$$ is the potentiometer's total value like 1kΩ or 10kΩ). As you move the slider contact, $$R_1$$'s resistance will increase as $$R_2$$'s resistance decreases. See animation below.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Animation showing how a potentiometer's two internal resistances R1 and R2 change as the wiper moves while always summing to the total resistance" autoplay loop muted playsinline>
   <source src="assets/videos/PotentiometerIntroduction_TrimmedAndCropped.mp4" type="video/mp4" />
 </video>
 **Video.** Animation by Jon Froehlich. Created in PowerPoint.
@@ -80,7 +80,7 @@ The power of a potentiometer is in that middle leg (Leg 2) whose resistance vari
 
 Using two multimeters set to **measure resistances** across both Legs 1-2 and 2-3, we can examine this behavior directly. Notice how as you move the wiper, the resistance across Legs 1 and 2 ($$R_{1}$$) and Legs 2 and 3 ($$R_{2}$$) proportionally change but always sum to $$R_{total}$$. We are using a 10kΩ potentiometer so $$R_{total}=10kΩ$$
 
-<video autoplay loop muted playsinline>
+<video aria-label="Tinkercad simulation with two multimeters measuring how the resistance across Legs 1-2 and Legs 2-3 of a 10k ohm potentiometer change as the wiper moves while summing to 10k ohms" autoplay loop muted playsinline>
   <source src="assets/videos/Tinkercad_PotentiometerWithMultimeters.mp4" type="video/mp4" />
 </video>
 **Video.** Using two multimeters, we can examine how the resistances change between Legs 1-2 and 2-3. Note that the resistance between the outer legs (Legs 1-3) will always sum to potentiometer's total value. In this case, we're using a 10kΩ, so it would sum to 10kΩ. Try it out on [Tinkercad here](https://www.tinkercad.com/things/4Aqy2AnmmMy-potentiometer-with-multimeters-measuring-resistance).
@@ -138,7 +138,7 @@ A fun introductory 3D-printing exercise is to design, model, and print your own 
 
 Even more fun is to combine your custom 3D prints with a microcontroller and to build custom applications that create new interactive experiences.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Custom 3D-printed potentiometer knobs being used as game controllers with an Arduino Leonardo and Processing sketches" autoplay loop muted playsinline>
   <source src="assets/videos/3DPrintedTrimPotKnobDemo2_TrimmedAndOptimized_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** A short video demonstrating the custom 3D printed potentiometer knobs being used as custom game controllers with an Arduino Leonardo and custom [Processing](https://processing.org/) sketches. The code for the Arduino+Processing "Etch-a-sketch" is [here](https://github.com/makeabilitylab/arduino/tree/master/Processing/ArduinoEtchASketch) and the code for the Arduino+Processing "Pong" is [here](https://github.com/makeabilitylab/arduino/tree/master/Processing/ArduinoPong). All 3D CAD designs and code by Jon Froehlich.
@@ -154,7 +154,7 @@ Just as our 3D-printed designs hint at, potentiometers have a long history as ga
 
 By moving the analog joystick, you independently control the two potentiometers in a voltage divider configuration. There is a $$V_{Out}$$ for the "Up/Down" potentiometer and a $$V_{Out}$$ for the "Left/Right" potentiometer. See the circuit diagram above.
 
-<video autoplay loop muted playsinline>
+<video aria-label="A 2-axis joystick being moved to show how physical movement is translated into an electrical signal by its two embedded potentiometers" autoplay loop muted playsinline>
   <source src="assets/videos/Parallax_2-AxisJoystick_TrimmedAndMuted.mp4" type="video/mp4" />
 </video>
 **Video.** A short snippet from this [official Parallax video](https://youtu.be/SXtPGAu4MMw) showing how physical movement of the joystick is translated into an electrical signal using two potentiometers.
@@ -176,7 +176,7 @@ As an example, let's hook up a potentiometer to 5V (Leg 1) and ground (Leg 3) an
 
 Now, let's see what happens as we change the wiper. Notice how $$V_{out}$$ changes according to $$V_{in} * \frac{R2}{(R1 + R2)}$$. In the video below, we are using a 1kΩ potentiometer but the function is the same.
 
-<video autoplay loop muted playsinline>
+<video aria-label="CircuitJS demonstration of how the output voltage of a 1k ohm potentiometer changes as the wiper moves, following the voltage divider equation" autoplay loop muted playsinline>
   <source src="assets/videos/PotentiometerIntroduction-VoltageDividerWithCircuitJS_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** A demonstration of how $$V_{out}$$ changes according to $$V_{in} * \frac{R2}{(R1 + R2)}$$. Animation made in PowerPoint and CircuitJS.
@@ -212,7 +212,7 @@ Because many potentiometers go from 0Ω to their max value, we must use a "backu
 {: .warning }
 > **Always use a backup resistor with variable resistors and LEDs.** This applies not just to potentiometers but to *all* variable resistors, including FSRs and photocells. A 220Ω or 330Ω backup resistor in series ensures the current never exceeds safe levels regardless of the variable resistor's position.
 
-<video autoplay loop muted playsinline>
+<video aria-label="Tinkercad simulation showing an LED burning out when a potentiometer is rotated to low resistance without a backup resistor in series" autoplay loop muted playsinline>
   <source src="assets/videos/PotentiometerWithBackupResistor_TinkercadCircuits_Cropped_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** Here's an example of what would happen if you rotated the potentiometer to low resistance without a backup resistor. Boom, another blown out LED. Video made with [Tinkercad](https://www.tinkercad.com/things/d6wWCmUhl7g) and Camtasia. 
@@ -234,7 +234,7 @@ For both Tinkercad Circuits, include a screenshot in your prototyping journals a
 
 After you've built and simulated the circuits in Tinkercad, we'd like you to physically build the breadboarded version with your hardware kits. Take a photo and a quick demo video of the circuit working and put them in your prototyping journals. Describe any challenges.
 
-<video autoplay loop muted playsinline>
+<video aria-label="A breadboarded trim potentiometer circuit with a backup resistor and red LED, dimming and brightening the LED as the potentiometer is adjusted" autoplay loop muted playsinline>
   <source src="assets/videos/TrimPotentiometer-IMG_5685_Trim-Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** Here's one possible way to breadboard a trim potentiometer circuit with a backup resistor and red LED. What did you make? Please take a similar video for your prototyping journals.
@@ -258,7 +258,7 @@ The force-sensitive resistor (FSR) responds to force or pressure. As an applied 
 
 Here's a video demonstration:
 
-<video autoplay loop muted playsinline>
+<video aria-label="A force-sensitive resistor LED circuit where pressing the FSR decreases resistance and makes the LED brighter" autoplay loop muted playsinline>
   <source src="assets/videos/FSR-TopDown9VCircuit-IMG_5683_Trimmed-Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** A video demonstration of an FSR-based LED circuit.
@@ -274,7 +274,7 @@ A light-dependent resistor (LDR)—sometimes called a photocell or photo-sensiti
 
 And the video demonstration:
 
-<video autoplay loop muted playsinline>
+<video aria-label="A light-dependent resistor LED circuit where shining a flashlight on the LDR decreases resistance and makes the red LED brighter" autoplay loop muted playsinline>
   <source src="assets/videos/Photocell-IMG_5686_Trim-Optimized.mp4" type="video/mp4" />
 </video>
 **Video.** A video demonstration of an LDR-based LED circuit.
@@ -298,7 +298,7 @@ For your prototyping journals, sketch out the circuit diagram for the DIY potent
 
 Here is an example DIY rotary potentiometer I made out of some cardboard, paper, a paper clip and a thumb tack (for the wiper), and a 12B pencil sketch (for the resistive material).
 
-<video autoplay loop muted playsinline>
+<video aria-label="A lo-fi DIY rotary potentiometer made from cardboard, paper, a paper clip and thumb tack wiper, and a 12B pencil graphite sketch as the resistive material" autoplay loop muted playsinline>
   <source src="assets/videos/DIY_Rotary_Pot-Reversed_AdobePremiere_720p_ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** A lo-fi rotary potentiometer made out of some cardboard, paper, a paper clip and a thumb tack (for the wiper), and a 12B pencil sketch (for the resistive material).
@@ -308,7 +308,7 @@ Here is an example DIY rotary potentiometer I made out of some cardboard, paper,
 
 Here is an example DIY slider potentiometer I made out of similar materials: cardboard, paper, a cardboard wiper with copper tape, and some 12B pencil sketch (for the resistive track).
 
-<video autoplay loop muted playsinline>
+<video aria-label="A lo-fi DIY slider potentiometer made from cardboard, paper, a copper-tape-wrapped cardboard slider, and a 12B pencil graphite sketch as the resistive track" autoplay loop muted playsinline>
   <source src="assets/videos/DIY_Slider_Pot-720p-Optimized-ByJonFroehlich.mp4" type="video/mp4" />
 </video>
 **Video.** A lo-fi slider potentiometer made out of some cardboard, paper, copper tape-wrapped cardboard (for the slider), and a 12B pencil sketch (for the resistive track).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,7 @@ Python utilities that bulk-edit or generate content across the textbook. They ar
 | [`fix_embedded_media.py`](fix_embedded_media.py) | Normalize `<video>` inline styles and wrap bare YouTube iframes responsively. | `--run` |
 | [`update_lesson_nav.py`](update_lesson_nav.py) | Migrate old `.btn` lesson nav to card-style `<nav class="lesson-nav">` (rewrites `.md`→`.html`). | `--run` |
 | [`fix_arduino_urls.py`](fix_arduino_urls.py) | Migrate old `arduino.cc` URLs to `docs.arduino.cc`. **Untested/brittle — use with care.** | `--apply` |
+| [`check_a11y.py`](check_a11y.py) | **Deprecated** local-only a11y spot-check (iframe `title`, video `aria-label`, image alt). **Not a CI gate** — superseded by pa11y-ci. Read-only. | _(none)_ |
 
 ## Details
 
@@ -86,6 +87,24 @@ to the card-style `<nav class="lesson-nav">`, converting link extensions from
 ```bash
 python scripts/update_lesson_nav.py           # dry run
 python scripts/update_lesson_nav.py --run      # apply
+```
+
+### `check_a11y.py` (deprecated)
+
+A fast, dependency-free local spot-check for three source-level a11y patterns:
+YouTube `<iframe>`s missing `title=`, `<video>`s missing `aria-label`, and images
+with empty alt (`![](...)`). Same published-page scope and draft/contributor
+exemptions as `check_seo_frontmatter.py`.
+
+> **Not a CI gate.** Accessibility enforcement is moving to off-the-shelf
+> [`pa11y-ci`](https://github.com/pa11y/pa11y-ci) (axe-core, run against the built
+> site), which covers far more of WCAG. Do **not** wire this script into
+> `content-lint.yml`; once pa11y-ci is in place it can be deleted (see issue #110).
+
+```bash
+python scripts/check_a11y.py            # full report, grouped by module
+python scripts/check_a11y.py --summary  # per-module counts only
+python scripts/check_a11y.py --ci       # exit 1 if any issue (local spot-check)
 ```
 
 ### `fix_arduino_urls.py`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ Python utilities that bulk-edit or generate content across the textbook. They ar
 | [`fix_embedded_media.py`](fix_embedded_media.py) | Normalize `<video>` inline styles and wrap bare YouTube iframes responsively. | `--run` |
 | [`update_lesson_nav.py`](update_lesson_nav.py) | Migrate old `.btn` lesson nav to card-style `<nav class="lesson-nav">` (rewrites `.md`→`.html`). | `--run` |
 | [`fix_arduino_urls.py`](fix_arduino_urls.py) | Migrate old `arduino.cc` URLs to `docs.arduino.cc`. **Untested/brittle — use with care.** | `--apply` |
-| [`check_a11y.py`](check_a11y.py) | **Deprecated** local-only a11y spot-check (iframe `title`, video `aria-label`, image alt). **Not a CI gate** — superseded by pa11y-ci. Read-only. | _(none)_ |
+| [`check_a11y.py`](check_a11y.py) | **Deprecated** local-only a11y spot-check (iframe `title`, video `aria-label`, image alt). **Not a CI gate** — superseded by html-proofer. Read-only. | _(none)_ |
 
 ## Details
 
@@ -96,10 +96,11 @@ YouTube `<iframe>`s missing `title=`, `<video>`s missing `aria-label`, and image
 with empty alt (`![](...)`). Same published-page scope and draft/contributor
 exemptions as `check_seo_frontmatter.py`.
 
-> **Not a CI gate.** Accessibility enforcement is moving to off-the-shelf
-> [`pa11y-ci`](https://github.com/pa11y/pa11y-ci) (axe-core, run against the built
-> site), which covers far more of WCAG. Do **not** wire this script into
-> `content-lint.yml`; once pa11y-ci is in place it can be deleted (see issue #110).
+> **Not a CI gate.** Content QA is moving to the off-the-shelf, Jekyll-native
+> [`html-proofer`](https://github.com/gjtorikian/html-proofer) gem (checks missing
+> image alt, broken links, and malformed HTML against the built `_site/`, with no
+> new toolchain). Do **not** wire this script into `content-lint.yml`; once
+> html-proofer is in place it can be deleted (see issue #110).
 
 ```bash
 python scripts/check_a11y.py            # full report, grouped by module

--- a/scripts/check_a11y.py
+++ b/scripts/check_a11y.py
@@ -1,13 +1,13 @@
 """
 check_a11y.py — quick local accessibility audit for embedded media and images.
 
-    DEPRECATED — NOT a CI gate. We are standardizing on off-the-shelf pa11y-ci
-    (axe-core, run against the built site) for accessibility enforcement, since
-    it covers far more of WCAG (contrast, heading order, ARIA, ...) and matches
-    the Makeability Lab website's tooling. This bespoke checker is kept only as a
-    fast, dependency-free local spot-check for the three source-level patterns
-    below. Do NOT wire it back into `.github/workflows/content-lint.yml`; once
-    pa11y-ci is in place and proven, this script can be deleted. See issue #110.
+    DEPRECATED — NOT a CI gate. We are standardizing on the off-the-shelf,
+    Jekyll-native html-proofer gem (run against the built _site/) for content
+    QA — it checks missing image alt, broken links, and malformed HTML, with no
+    new toolchain. This bespoke checker is kept only as a fast, dependency-free
+    local spot-check for the three source-level patterns below. Do NOT wire it
+    back into `.github/workflows/content-lint.yml`; once html-proofer is in place
+    and proven, this script can be deleted. See issue #110.
 
 Scans published .md pages for three common, mechanically-detectable a11y gaps:
 

--- a/scripts/check_a11y.py
+++ b/scripts/check_a11y.py
@@ -1,0 +1,181 @@
+"""
+check_a11y.py — quick local accessibility audit for embedded media and images.
+
+    DEPRECATED — NOT a CI gate. We are standardizing on off-the-shelf pa11y-ci
+    (axe-core, run against the built site) for accessibility enforcement, since
+    it covers far more of WCAG (contrast, heading order, ARIA, ...) and matches
+    the Makeability Lab website's tooling. This bespoke checker is kept only as a
+    fast, dependency-free local spot-check for the three source-level patterns
+    below. Do NOT wire it back into `.github/workflows/content-lint.yml`; once
+    pa11y-ci is in place and proven, this script can be deleted. See issue #110.
+
+Scans published .md pages for three common, mechanically-detectable a11y gaps:
+
+  1. YouTube <iframe> without a `title=` attribute (screen readers announce a
+     generic "iframe" with no context).
+  2. <video> without an `aria-label` attribute (same problem for video heroes).
+  3. Markdown images with empty or missing alt text — `![](...)` — on a
+     published page.
+
+Detection is intentionally conservative (only the patterns above, only on
+published pages) so it can run as a non-flaky CI gate alongside
+check_seo_frontmatter.py. Drafts (`nav_exclude`/`search_exclude`) and
+contributor/deprecated docs are exempt, mirroring the SEO gate.
+
+Modes:
+    python scripts/check_a11y.py            # full report, grouped by module (exit 0)
+    python scripts/check_a11y.py --summary  # per-module counts only
+    python scripts/check_a11y.py --ci       # exit 1 if any issue found (local spot-check only)
+
+Prints ASCII only (avoids cp1252 crashes on Windows consoles).
+"""
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+DOCS_DIR = "."
+SKIP_DIRS = {"_site", ".git", "node_modules", "vendor", ".jekyll-cache",
+             "scripts", "_includes", "_layouts", "_data", "_sass", "assets"}
+
+# Pages exempt from the a11y requirement (contributor docs, deprecated).
+IGNORE = {
+    "website-dev.md", "website-install.md", "teaching-notes.md",
+    "website-content-ideas.md", "README.md", "LICENSE.md", "CLAUDE.md",
+    "404.md", "arduino/potentiometers-old.md",
+}
+
+FRONT_MATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# A full <iframe ...> ... </iframe> (or self-contained opening tag) — captured so
+# we can test individual attributes. Non-greedy up to the first '>'.
+IFRAME_OPEN_RE = re.compile(r"<iframe\b[^>]*>", re.IGNORECASE)
+VIDEO_OPEN_RE = re.compile(r"<video\b[^>]*>", re.IGNORECASE)
+
+YOUTUBE_RE = re.compile(r"youtube\.com|youtu\.be", re.IGNORECASE)
+TITLE_ATTR_RE = re.compile(r'\btitle\s*=\s*"[^"]*"', re.IGNORECASE)
+ARIA_LABEL_RE = re.compile(r'\baria-label\s*=\s*"[^"]*"', re.IGNORECASE)
+
+# Markdown image with empty alt: ![](...) — allow whitespace inside the brackets.
+EMPTY_ALT_RE = re.compile(r"!\[\s*\]\(")
+
+
+def front_matter(content):
+    m = FRONT_MATTER_RE.match(content)
+    return (m.group(1), content[m.end():]) if m else (None, content)
+
+
+def fm_true(fm, key):
+    return bool(re.search(rf"^{key}:\s*true\s*$", fm, re.MULTILINE | re.IGNORECASE))
+
+
+def line_of(body, idx):
+    """1-based line number of character offset idx within body."""
+    return body.count("\n", 0, idx) + 1
+
+
+def scan_body(body):
+    """Return a list of (line_no, kind, snippet) issues for one page body."""
+    visible = HTML_COMMENT_RE.sub(lambda m: "\n" * m.group(0).count("\n"), body)
+    issues = []
+
+    for m in IFRAME_OPEN_RE.finditer(visible):
+        tag = m.group(0)
+        if YOUTUBE_RE.search(tag) and not TITLE_ATTR_RE.search(tag):
+            issues.append((line_of(visible, m.start()), "iframe-no-title",
+                           tag[:80]))
+
+    for m in VIDEO_OPEN_RE.finditer(visible):
+        tag = m.group(0)
+        if not ARIA_LABEL_RE.search(tag):
+            issues.append((line_of(visible, m.start()), "video-no-aria-label",
+                           tag[:80]))
+
+    for m in EMPTY_ALT_RE.finditer(visible):
+        issues.append((line_of(visible, m.start()), "empty-alt",
+                       visible[m.start():m.start() + 80].replace("\n", " ")))
+
+    return sorted(issues)
+
+
+def rel(p):
+    return str(p).replace("\\", "/").lstrip("./")
+
+
+def module_of(relpath):
+    return relpath.split("/")[0] if "/" in relpath else "(root)"
+
+
+def collect():
+    """Return {relpath: [issues]} for all published pages with issues."""
+    results = {}
+    checked = 0
+    for path in sorted(Path(DOCS_DIR).rglob("*.md")):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        relpath = rel(path)
+        if relpath in IGNORE:
+            continue
+        fm, body = front_matter(path.read_text(encoding="utf-8"))
+        if fm is None or not re.search(r"^layout:", fm, re.MULTILINE):
+            continue
+        if fm_true(fm, "nav_exclude") or fm_true(fm, "search_exclude"):
+            continue
+        checked += 1
+        issues = scan_body(body)
+        if issues:
+            results[relpath] = issues
+    return results, checked
+
+
+KINDS = ("iframe-no-title", "video-no-aria-label", "empty-alt")
+
+
+def main():
+    summary_only = "--summary" in sys.argv
+    ci = "--ci" in sys.argv
+
+    results, checked = collect()
+    total = sum(len(v) for v in results.values())
+
+    # Per-module tallies.
+    by_module = defaultdict(lambda: defaultdict(int))
+    for relpath, issues in results.items():
+        mod = module_of(relpath)
+        for _, kind, _ in issues:
+            by_module[mod][kind] += 1
+
+    print(f"Checked {checked} published page(s); "
+          f"{total} a11y issue(s) in {len(results)} file(s).\n")
+
+    print(f"{'module':<16}{'iframe':>9}{'video':>9}{'alt':>9}{'total':>9}")
+    print("-" * 52)
+    for mod in sorted(by_module, key=lambda m: -sum(by_module[m].values())):
+        c = by_module[mod]
+        tot = sum(c.values())
+        print(f"{mod:<16}{c['iframe-no-title']:>9}"
+              f"{c['video-no-aria-label']:>9}{c['empty-alt']:>9}{tot:>9}")
+    print("-" * 52)
+    gt = {k: sum(by_module[m][k] for m in by_module) for k in KINDS}
+    print(f"{'TOTAL':<16}{gt['iframe-no-title']:>9}"
+          f"{gt['video-no-aria-label']:>9}{gt['empty-alt']:>9}{total:>9}")
+
+    if not summary_only:
+        print()
+        for relpath in sorted(results, key=lambda p: (module_of(p), p)):
+            print(f"\n{relpath}")
+            for line_no, kind, snippet in results[relpath]:
+                print(f"  L{line_no:<5} {kind:<20} {snippet}")
+
+    if ci and total:
+        print(f"\nERROR: {total} accessibility issue(s) found on published pages.")
+        print("Add title= to YouTube iframes, aria-label to <video>, and "
+              "descriptive alt text to images.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sensors/hall-effect.md
+++ b/sensors/hall-effect.md
@@ -52,7 +52,7 @@ Confused? That's ok!
 To better understand the Hall effect, watch this 5-minute video from Professor Bowley at the University of Nottingham. He provides a wonderful set of visual experiments and explanations (the best we've seen) that should clarify things:
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/AcRCgyComEw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Professor Bowley of the University of Nottingham explains the physics of the Hall effect with visual experiments" src="https://www.youtube.com/embed/AcRCgyComEw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 In this [wonderful video](https://youtu.be/AcRCgyComEw) from the University of Notthingham, Professor Bowley explains the physics of the Hall Effect.
 {: .fs-1 }
@@ -121,7 +121,7 @@ With a Hall effect sensor, the magnetic flux density through the sensor is maxim
 Here's a [video](https://youtu.be/hnCEQYO-i_E) demonstrating a reed switch functioning with three different magnets from K&J Magnetics:
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/hnCEQYO-i_E" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Demonstration of a reed switch closing in response to three different magnets, from K&amp;J Magnetics" src="https://www.youtube.com/embed/hnCEQYO-i_E" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 
@@ -182,7 +182,7 @@ We've included two wiring diagrams: on the left, the suggested wiring by the DRV
 And here's a workbench video demonstrating the circuit (without a capacitor). The second half of the video includes two multimeters: one to measure the current through the circuit and the other to measure the voltage output from the Hall effect sensor. 
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/RLNx7tHCxC0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench demo of the Hall effect LED brightener circuit with multimeters measuring current and sensor output voltage" src="https://www.youtube.com/embed/RLNx7tHCxC0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 My vocal narration is quite soft as I recorded the video early in the morning and did not want to disturb my house! :D
 {: .fs-1 }
@@ -219,7 +219,7 @@ This [source code](https://github.com/makeabilitylab/arduino/blob/master/Sensors
 ### Workbench video
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/MvVfq6AAEQU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench demo of the Arduino-based magnetic LED brightener that adjusts LED brightness from the Hall effect sensor" src="https://www.youtube.com/embed/MvVfq6AAEQU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <!-- ## Reed switches

--- a/sensors/photoresistors.md
+++ b/sensors/photoresistors.md
@@ -37,7 +37,7 @@ As one example use case in consumer toys, this Melissa and Doug wooden fire truc
 ![Picture showing the Melissa and Doug puzzle with embedded photoresistors](assets/images/Photoresistor_MelissaAndDougPuzzle.png)
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/ySJw510mVgs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Melissa and Doug wooden fire truck puzzle using embedded photoresistors to detect placed pieces and play a siren when complete" src="https://www.youtube.com/embed/ySJw510mVgs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 Each puzzle piece location has a respective embedded photoresistor, which is used to track whether a piece has been placed or not. When the puzzle is completed (and all photoresistors have been covered), the puzzle plays a fire truck siren. There are a few limitations to this sensing technique: while cheap, the "fire truck" siren can be triggered when the photoresistors are covered (either accidentally via an errant puzzle piece or hand or on purpose), occassionally the siren will be triggered before the puzzle is actually completed (just when the last puzzle piece is hovering over the remaining location), and, of course, the sensing method cannot tell whether a puzzle piece is in the correct position (which is fine if one just needs to infer when the puzzle is completed and not, for example, to help guide a child in completing the puzzle).
 {: .fs-1 }
@@ -45,7 +45,7 @@ Each puzzle piece location has a respective embedded photoresistor, which is use
 Another example use case from inexpensive consumer electronics: an auto-brightening nightlight from General Electric, which gets brighter as the ambient light gets darker.
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/EkBDjZZ3v00" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="A General Electric auto-brightening nightlight that gets brighter as the ambient light gets darker" src="https://www.youtube.com/embed/EkBDjZZ3v00" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 An auto-brightness fading night light from General Electric.
 {: .fs-1 }
@@ -124,7 +124,7 @@ Here's the results of our own informal experiments:
 And a video:
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/imbN0PtUQg0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Measuring photoresistor resistance with a multimeter as lighting changes, ranging from 1.6 kilohms to over 10 megohms" src="https://www.youtube.com/embed/imbN0PtUQg0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 Our photoresistor ranges from 1.6kΩ with our desk lamp to 10kΩ with the lights off to over ~10MΩ when covered by a coffee cup.
 {: .fs-1 }
@@ -148,7 +148,7 @@ Try making this circuit. What happens?
 Because the photoresistor resistance **decreases** with light levels, the LED gets brighter as the ambient light gets brighter. This is the opposite behavior of what we want! See video below.
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/tNOG2tYaBQU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Photoresistor wired in series with an LED, so the LED gets brighter as ambient light increases (the opposite of a nightlight)" src="https://www.youtube.com/embed/tNOG2tYaBQU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 In this video, the photoresistor is in series with the LED. As the ambient light level increases, the photoresistor resistance decreases, and the LED gets brighter. But we want the opposite effect? Remember, we are using the Arduino only for power here. Note: this video has no audio.
 {: .fs-1 }
@@ -161,7 +161,7 @@ Let's try it.
 
 We are going to create an inverse relationship between ambient light levels and LED brightness by placing the LED in parallel with the photoresistor wired in a voltage divider configuration. Now, as the photoresistor resistance drops, the LED will get brighter. The key is in selecting an appropriate fixed resistor $$R$$. 
 
-![](assets/images/Photoresistor_WiringDiagramAndSchematicVoltageDivider_NoArduino_Fritzing.png)
+![Wiring diagram and schematic of a photoresistor in a voltage divider with an LED in parallel, no Arduino](assets/images/Photoresistor_WiringDiagramAndSchematicVoltageDivider_NoArduino_Fritzing.png)
 
 If $$R$$ is too small, the LED will still turn on even in ambient light. Through experimentation, we determined that $$R=4.7kΩ$$ resulted in the best performance: a 1.72V drop and 0.10mA through the LED with a **desk lamp off** and a 0.8V drop and 0mA through the LED with the **lamp on**. 
 
@@ -175,7 +175,7 @@ If $$R$$ is too small, the LED will still turn on even in ambient light. Through
 So, while this circuit works, it doesn't work well. We are not able to sufficiently control the current through the LED based on lighting conditions. Yes, we have the general LED behavior we want but 0.10mA is a very small current, so the LED is not very bright (even in the darkest conditions). See video below.
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/ZYVQLw-7HU0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Photoresistor wired in parallel with an LED in a voltage divider to dim the LED as ambient light increases" src="https://www.youtube.com/embed/ZYVQLw-7HU0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 This video shows a photoresistor wired in parallel with an LED in a voltage divider to inverse the relationship between ambient light levels and LED brightness. Again, the Arduino is used solely for power. Note: this video has no audio.
 {: .fs-1 }
@@ -308,7 +308,7 @@ This [source code](https://github.com/makeabilitylab/arduino/blob/master/Sensors
 ### Workbench video
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/CIhCJCBrOYU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Workbench demo of the Arduino auto-on nightlight that brightens an LED as the room gets darker using a photoresistor" src="https://www.youtube.com/embed/CIhCJCBrOYU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Exercises

--- a/sensors/potentiometers.md
+++ b/sensors/potentiometers.md
@@ -14,7 +14,7 @@ Please see our [Potentiometers lesson](../arduino/potentiometers.md) as part of 
 Are Potentiometers even sensors? Well, they are a type of variable resistor and often used to sense human input, so I would say yes! :)
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/5qxQheanSkQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="Demonstration of a trimpot on Arduino analog input A0 with its changing value graphed in real time on an OLED display" src="https://www.youtube.com/embed/5qxQheanSkQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 A [video](https://youtu.be/5qxQheanSkQ) demonstration of a [trimpot](https://www.adafruit.com/product/356) hooked up to analog input A0 on the Arduino and its value graphed on an OLED display in real-time. The code is available [here](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogGraph/AnalogGraph.ino).

--- a/signals/jupyter-notebook.md
+++ b/signals/jupyter-notebook.md
@@ -69,7 +69,7 @@ To install the `nbextensions`, open your terminal (on linux or Mac) or the Anaco
 
 Restart Jupyter Notebook and you should see a tab called `Nbextensions` on the home screen. Click on that tab and then you should see all nbextensions. Click on `Table of Contents (2)` to configure and Enable it. See screenshots below.
 
-![](assets/images/JupyterNotebook_TOC2_ConfigurableNbextensions_TOC2.png)
+![Jupyter Notebook Nbextensions configuration tab with the Table of Contents (2) extension enabled](assets/images/JupyterNotebook_TOC2_ConfigurableNbextensions_TOC2.png)
 
 #### Step 3: Try out TOC
 


### PR DESCRIPTION
## What

Accessibility content sweep (V2.0 item D) fixing **103 mechanically-detectable a11y issues across 16 published pages**.

| module | iframe (no `title`) | video (no `aria-label`) | empty image alt | total |
|---|---|---|---|---|
| cpx | 0 | 14 | 34 | 48 |
| electronics | 0 | 19 | 0 | 19 |
| advancedio | 0 | 7 | 7 | 14 |
| sensors | 11 | 0 | 1 | 12 |
| arduino | 7 | 2 | 0 | 9 |
| signals | 0 | 0 | 1 | 1 |
| **total** | **18** | **42** | **43** | **103** |

The exemplar modules (`communication`, `esp32`) were already clean.

## How

Surgical edits: each change adds only the missing `title=` / `aria-label` attribute or alt text on the flagged element — no reformatting (101 lines changed, 1:1). Text *describes the actual media* using each page's surrounding context and captions (e.g. "A potentiometer's raw analog input oscillating between 142 and 143 while untouched, with the noise removed by a moving average filter"), not generic placeholders.

## Enforcement → html-proofer (follow-up, not this PR)

The content-QA **gate** will be a follow-up using the off-the-shelf, Jekyll-native [`html-proofer`](https://github.com/gjtorikian/html-proofer) gem — run against the built `_site/` it flags missing image `alt`, broken links, and malformed HTML, with no new toolchain (Ruby is already in the stack). Tracked in #110.

`scripts/check_a11y.py` is included **only as a deprecated, local-only spot-check** (the audit that found these 103 issues). It is explicitly **not** wired into CI and is documented as such in its docstring and `scripts/README.md`; it will be deleted once html-proofer lands.

## Verification

Full `bundle exec jekyll build` succeeds (no errors); spot-checked the rendered `_site/` HTML to confirm the new `title=` / `aria-label` / `alt=` attributes emit correctly.

## Out of scope

Color-only wiring/circuit instructions (not auto-detectable) are tracked in #111.

Part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
