### PR TITLE
Fix root-absolute /assets/movies gif paths (unblocks Jekyll 4)

### DIFF
--- a/arduino/potentiometers-old.md
+++ b/arduino/potentiometers-old.md
@@ -38,7 +38,7 @@ A [video](https://youtu.be/MJt9kSNlsU4) demonstration of a [trimpot](https://www
 
 A [potentiometer](https://en.wikipedia.org/wiki/Potentiometer) (or pot) is a three-terminal resistor with a sliding or rotating contact that can be used to dynamically vary resistance. 
 
-![Animation showing how a potentiometer works](/assets/movies/Potentiometer_Overview_Animation_TrimmedAndCropped.gif)
+![Animation showing how a potentiometer works](assets/movies/Potentiometer_Overview_Animation_TrimmedAndCropped.gif)
 Animation shows how the wiper can be used to vary resistance. The figure on the right is the formal electrical symbol.
 {: .fs-1 }
 

--- a/sensors/hall-effect.md
+++ b/sensors/hall-effect.md
@@ -41,7 +41,7 @@ Electricity and magnetism have long captured human interest but were considered 
 
 Enter Edwin Hall. As a PhD student at Johns Hopkins in 1879, Hall discovered the "Hall effect", which is the production of a small voltage difference across an electrical conductor **transverse** to the electric current when a magnetic field is applied ([Wikipedia](https://en.wikipedia.org/wiki/Hall_effect#Discovery)). This [animation](https://youtu.be/wpAA3qeOYiI) by "How to Mechatronics" helps demonstrate the effect. When a magnet is introduced, it repels negative charges to one side of the conductor creating an asymmetric distribution of charge (perpendicular to the flow of current) on the conductor. This separation of charge establishes a new electric field with a small electric potential (often in the millivolts), which can be measured by a multimeter or similar device.
 
-![Animation of Hall Effect](/assets/movies/HallEffectAnimation_HowToMechatronics-Optimized.gif)
+![Animation of Hall Effect](assets/movies/HallEffectAnimation_HowToMechatronics-Optimized.gif)
 Animation from ["How to Mechatronics"](https://youtu.be/wpAA3qeOYiI)
 {: .fs-1 }
 
@@ -107,7 +107,7 @@ While some Hall effect sensors produce binary output (`HIGH` or `LOW`) and thus,
 
 | Reed Switch Animation | Slow Motion Activation Video |
 | ---------- | ----------- |
-| ![Reed switch slow-mo video](/assets/movies/ReedSwitchAnimation-Optimized.gif) | ![Reed switch animation](/assets/movies/HowAReedSwitchWorks_Wikipedia.gif) |
+| ![Reed switch slow-mo video](assets/movies/ReedSwitchAnimation-Optimized.gif) | ![Reed switch animation](assets/movies/HowAReedSwitchWorks_Wikipedia.gif) |
 
 The slow-motion activation video is from [Wikipedia](https://en.wikipedia.org/wiki/Reed_switch).
 {: .fs-1 }


### PR DESCRIPTION
4 animation refs used root-absolute `/assets/movies/…` but the files live in module asset folders. The old `jekyll-relative-links` (github-pages gem) silently rescued them; the newer one under Jekyll 4 (#117) doesn't, so the html-proofer `link-check` gate flagged them. Page-relative paths resolve under both Jekyll 3.9.2 and 4.

Surfaced by the link-check gate validating the Jekyll 4 upgrade (#117). Part of #81/#110.