### PR TITLE
Standardize code blocks on fenced ```lang + markdownlint CI gate (#99)

### DIFF
--- a/.github/workflows/content-lint.yml
+++ b/.github/workflows/content-lint.yml
@@ -3,7 +3,8 @@
 # Runs lightweight checks on the Markdown content. Separate from the deploy
 # workflow (jekyll.yml) on purpose: a content-convention miss should block a
 # MERGE, but never take down the live site. This is also the home for future
-# content gates (e.g. the #99 code-block standardization lint).
+# content gates. Current gates: SEO front matter, media a11y, code-block
+# standardization (#99), and html-proofer link/anchor/HTML validation.
 name: Content lint
 
 on:
@@ -44,6 +45,27 @@ jobs:
 
       - name: Check media a11y (iframe title, video aria-label, image alt)
         run: python scripts/check_a11y.py --ci
+
+  code-blocks:
+    # Enforce #99 code-block standardization on the Markdown SOURCE: every fenced
+    # block declares a language (MD040), blocks are fenced not indented (MD046),
+    # and fences use backticks (MD048). Uses markdownlint-cli (NOT cli2) with -c
+    # so the scoped .markdownlint-code.jsonc fully replaces config instead of
+    # merging the editor .markdownlint.jsonc back in. House style: ```cpp for all
+    # Arduino/ESP32 sketches. Deliberate indented demos opt out inline with
+    # <!-- markdownlint-disable MD046 -->.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Lint code-block conventions (MD040/MD046/MD048)
+        run: npx --yes markdownlint-cli@0.48.0 -c .markdownlint-code.jsonc "**/*.md" --ignore "_site" --ignore "node_modules"
 
   link-check:
     # Validate the BUILT site with html-proofer: broken internal links, broken

--- a/.markdownlint-code.jsonc
+++ b/.markdownlint-code.jsonc
@@ -1,0 +1,24 @@
+{
+  // Scoped markdownlint config for the CI "code-blocks" gate (issue #99).
+  //
+  // This is INTENTIONALLY separate from the editor config (.markdownlint.jsonc):
+  // it checks ONLY the code-block standardization rules so the gate can't fail
+  // on the many unrelated style nits (MD009/MD022/MD032/...) that the content
+  // predates. The CI job runs it via `markdownlint-cli -c` (which fully replaces
+  // config, rather than markdownlint-cli2 which merges the discovered editor
+  // config back in). Filename is non-standard on purpose so no tool auto-loads
+  // it for editing.
+  "default": false,
+
+  // MD040: every fenced code block must declare a language token (e.g. ```cpp,
+  // ```bash, ```text). cpp is the house style for all Arduino/ESP32 sketches.
+  "MD040": true,
+
+  // MD046: code blocks must be fenced, never indented (an indented block can't
+  // carry a language token, so it would silently evade MD040). Deliberate
+  // indented demos opt out inline with <!-- markdownlint-disable MD046 -->.
+  "MD046": { "style": "fenced" },
+
+  // MD048: fences use backticks (```), not tildes (~~~), for consistency.
+  "MD048": { "style": "backtick" }
+}

--- a/advancedio/addressable-leds.md
+++ b/advancedio/addressable-leds.md
@@ -203,7 +203,7 @@ The Adafruit NeoPixel library can be installed directly from the Arduino Library
 
 The NeoPixel library API will feel familiar if you've completed the [OLED lesson](oled.md)—it follows the same **buffer → display** pattern:
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;       // Any digital pin works — no PWM required!
@@ -219,7 +219,7 @@ void setup() {
   strip.setBrightness(50);   // Set brightness (0-255). 50 is ~20% bright
   strip.show();              // Initialize all pixels to 'off'
 }
-{% endhighlight C++ %}
+```
 
 {: .note }
 > Notice the same **buffer → show** pattern from the [OLED lesson](oled.md): `setPixelColor()` writes to a buffer in RAM, and `show()` pushes the data to the LEDs. If you forget to call `show()`, nothing will change on the LEDs—just like forgetting `_display.display()` on the OLED!
@@ -247,7 +247,7 @@ Here are the most commonly used functions from the [Adafruit NeoPixel library](h
 
 Each pixel's color is specified using RGB values from an 8-bit value—0-255 per channel—just like the [RGB LED lesson](../arduino/rgb-led.md). Some examples:
 
-{% highlight C++ %}
+```cpp
 // Named colors using strip.Color(R, G, B)
 uint32_t red    = strip.Color(255, 0, 0);
 uint32_t green  = strip.Color(0, 255, 0);
@@ -255,11 +255,11 @@ uint32_t blue   = strip.Color(0, 0, 255);
 uint32_t white  = strip.Color(255, 255, 255);
 uint32_t purple = strip.Color(128, 0, 255);
 uint32_t off    = strip.Color(0, 0, 0);
-{% endhighlight C++ %}
+```
 
 For animations that cycle through colors, the **HSV** (hue, saturation, value) color space is much more useful than RGB. Remember the [HSL crossfading lesson](../arduino/rgb-led-fade.md)? The same principle applies here. The `ColorHSV()` function lets you smoothly sweep through the entire rainbow by varying just the hue value:
 
-{% highlight C++ %}
+```cpp
 // Hue ranges from 0 to 65535 (full color wheel)
 // 0 = red, ~10922 = yellow, ~21845 = green, ~32768 = cyan,
 // ~43690 = blue, ~54613 = magenta, 65535 wraps back to red
@@ -269,7 +269,7 @@ uint32_t color = strip.ColorHSV(hue, 255, 255); // Full sat, full brightness
 // Note: ColorHSV returns a value that should be passed through strip.gamma32()
 // for perceptually accurate colors:
 strip.setPixelColor(i, strip.gamma32(strip.ColorHSV(hue, 255, 255)));
-{% endhighlight C++ %}
+```
 
 {: .note }
 > **What is `gamma32()`?** Human eyes perceive brightness non-linearly—the difference between 0 and 50 looks much bigger than the difference between 200 and 250. The `gamma32()` function applies a correction curve so that color transitions look smooth and natural to our eyes. It's optional but makes a noticeable difference in gradients and fades.
@@ -381,7 +381,7 @@ Now that we understand how addressable LEDs work and have our stick wired up, le
 
 Let's start by simply setting each LED to a different color. This confirms that your wiring is correct and that the library is communicating with all 8 LEDs. This is our equivalent of the [shape drawing activity](oled.md#activity-draw-shapes-and-text) from the OLED lesson—the simplest possible test.
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;
@@ -409,7 +409,7 @@ void setup() {
 void loop() {
   // Nothing to do — the colors persist until changed
 }
-{% endhighlight C++ %}
+```
 
 If your colors look wrong (*e.g.,* you asked for red but got green), try changing `NEO_GRB` to `NEO_RGB` in the strip constructor. This is the most common issue students encounter!
 
@@ -423,7 +423,7 @@ Try playing with the colors by changing the RGB values above. Our code for this 
 
 Now let's create a classic rainbow animation that cycles smoothly across all 8 LEDs. This introduces the concept of **animation on LED strips**: update pixel colors, call `show()`, wait a bit, repeat. It's the same pattern we used for the [bouncing ball](oled.md#activity-draw-a-bouncing-ball) on the OLED.
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;
@@ -456,7 +456,7 @@ void loop() {
 
   delay(20); // ~50 fps
 }
-{% endhighlight C++ %}
+```
 
 Try changing the `HUE_STEP` constant to `64` (slower rainbow) or `512` (faster rainbow). What happens if you change `setBrightness()` to 255? (Shield your eyes!).
 
@@ -490,7 +490,7 @@ Use the same LED wiring as before, and add a 10KΩ potentiometer with its wiper 
 
 #### The code
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;
@@ -527,7 +527,7 @@ void loop() {
 
   delay(20);
 }
-{% endhighlight C++ %}
+```
 
 As you turn the potentiometer, you should see all 8 LEDs smoothly cycle through the rainbow together.
 
@@ -549,7 +549,7 @@ Now let's add a **second potentiometer** on `A1` to independently control bright
 **Video.** A circuit diagram for the potentiometer-controlled hue and brightness example. You can view and play with this example on [Tinkercad](https://www.tinkercad.com/things/53EaKIvUCsX-neopixel-strip-8-pot-controlled-hue-and-brightness).
 {: .fs-1 }
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;
@@ -590,7 +590,7 @@ void loop() {
 
   delay(20);
 }
-{% endhighlight C++ %}
+```
 
 Try turning each knob independently—you can dial in any color at any brightness level. Notice how the `ColorHSV()` function's three parameters (hue, saturation, value) map perfectly to physical controls. What would you use a *third* potentiometer for? (Hint: saturation controls how vivid *vs.* pastel the color looks!)
 
@@ -608,7 +608,7 @@ For our final activity, let's build a **level meter** (or VU meter)—a bar-grap
 
 We'll color the LEDs from green (low) through yellow (mid) to red (high), like a classic audio level meter.
 
-{% highlight C++ %}
+```cpp
 #include <Adafruit_NeoPixel.h>
 
 const int LED_PIN = 2;
@@ -653,7 +653,7 @@ void loop() {
 
   delay(30);
 }
-{% endhighlight C++ %}
+```
 
 Turn the potentiometer and watch the LEDs fill up like a progress bar! This is a simple but satisfying example of mapping data to a physical display. Try replacing the potentiometer with a [force-sensitive resistor](../arduino/force-sensitive-resistors.md) or a [photoresistor](../sensors/photoresistors.md) for a more interactive experience.
 

--- a/advancedio/oled.md
+++ b/advancedio/oled.md
@@ -218,7 +218,7 @@ Below, we describe how to draw shapes, text, and bitmaps. Importantly, when you 
 
 Let's begin by drawing a circle at `x,y` location of `50,20` with a radius of `10`. We'll start first with pseudocode to understand the drawing pipeline, then show actual C++.
 
-```
+```text
 // One-time initialization
 Adafruit_SSD1306 _disp(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 _disp.begin(SSD1306_SWITCHCAPVCC, 0x3D); // Allocate RAM for image buffer, set VCC, and I2C address
@@ -231,7 +231,7 @@ _disp.display();                             // Render offscreen buffer to displ
 
 And here's the actual C++ implementation (the full code is on GitHub as [DrawCircle.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/DrawCircle/DrawCircle.ino)).
 
-{% highlight C++ %}
+```cpp
 // Instantiate SSD1306 driver display object
 Adafruit_SSD1306 _display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
@@ -259,11 +259,11 @@ void loop(){
   // Render graphics buffer to screen
   _display.display();
 }
-{% endhighlight C++ %}
+```
 
 Now, because we are drawing the exact same thing on every `loop()` call, we could just as well put this drawing code into `setup()` and have it draw once and only once (the graphic content will persist).
 
-{% highlight C++ %}
+```cpp
 // Instantiate SSD1306 driver display object
 Adafruit_SSD1306 _display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
@@ -291,7 +291,7 @@ void loop(){
   // Empty on purpose to make a point about how graphic content persists
   // on screen
 }
-{% endhighlight C++ %}
+```
 
 However, for practical purposes, we always want to put our drawing methods in `loop()` because we want to support **dynamic graphics**, which are animated (*e.g.,* graphics that change over time) and/or responsive (*e.g.,* graphics that change in response to input).
 
@@ -348,21 +348,21 @@ Rather than call `Serial.print("Hello World")`, however, with the OLED display a
 
 To use the OLED's print functionality, you can first set optional parameters such as the text color, size, and wrapping:
 
-{% highlight C++ %}
+```cpp
 void setTextColor(uint16_t color);
 void setTextColor(uint16_t color, uint16_t backgroundcolor);
 void setTextSize(uint8_t size);
 void setTextWrap(boolean w);
-{% endhighlight C++ %}
+```
 
 Then, to position the text, you set the print cursor with:
-{% highlight C++ %}
+```cpp
 void setCursor(uint16_t x0, uint16_t y0);
-{% endhighlight C++ %}
+```
 
 Finally, to print the text at that cursor position, you can call any of the standard [`Serial.print`](https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Print.h) methods, including this subset:
 
-{% highlight C++ %}
+```cpp
 size_t print(const String &);
 size_t print(const char[]);
 size_t print(char);
@@ -370,7 +370,7 @@ size_t print(char);
 size_t println(const String &s);
 size_t println(const char[]);
 size_t println(char);
-{% endhighlight C++ %}
+```
 
 See the [Serial.print() docs](https://www.arduino.cc/reference/en/language/functions/communication/serial/print/) or the [Print.h](https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Print.h) library for more on the `print` API, or read on for an example.
 
@@ -378,7 +378,7 @@ See the [Serial.print() docs](https://www.arduino.cc/reference/en/language/funct
 
 In creative coding, visualization, and game dev, we often want to center or otherwise align text. To do so, we need to **measure** it. Fortunately, the [Adafruit GFX](https://github.com/adafruit/Adafruit-GFX-Library/blob/master/Adafruit_GFX.h) library has a method called `getTextBounds` that does just that!
 
-{% highlight C++ %}
+```cpp
 /**************************************************************************/
 /*!
     @brief  Helper to determine size of a string with current font/size.
@@ -393,11 +393,11 @@ In creative coding, visualization, and game dev, we often want to center or othe
 */
 /**************************************************************************/
 void getTextBounds(String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-{% endhighlight C++ %}
+```
 
 For example, in our [HelloWorld.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/HelloWorld/HelloWorld.ino) example, we center the text "Hello Makers!" both vertically and horizontally on the OLED screen. The key excerpt is here:
 
-{% highlight C++ %}
+```cpp
 int16_t x, y;
 uint16_t textWidth, textHeight;
 const char strHello[] = "Hello Makers!";
@@ -418,7 +418,7 @@ _display.print(strHello);
 
 // Render the graphics buffer to screen
 _display.display(); 
-{% endhighlight C++ %}
+```
 
 ##### Inverting text
 
@@ -440,7 +440,7 @@ While you can use either `drawChar` or `write`, the latter uses the currently se
 
 To draw a happy face—which is char index `2`—in the middle of the screen, for example, we could use `drawChar`:
 
-{% highlight C++ %}
+```cpp
 const int CHAR_WIDTH = 5;
 const int CHAR_HEIGHT = 8;
 
@@ -453,11 +453,11 @@ uint16_t yText = _display.height() / 2 - charHeight / 2;
 uint16_t xText = _display.width() / 2 - charWidth / 2;
 
 _display.drawChar(xText, yText, (char)charIndex, SSD1306_WHITE, SSD1306_BLACK, charSize);
-{% endhighlight C++ %}
+```
 
 Or we could also use the `write()` method:
 
-{% highlight C++ %}
+```cpp
 int16_t x1, y1;
 uint16_t textWidth, textHeight;
 int charIndex = 2; // for smiley face
@@ -468,7 +468,7 @@ uint16_t yText = _display.height() / 2 - textHeight / 2;
 uint16_t xText = _display.width() / 2 - textWidth / 2;
 _display.setCursor(xText, yText);
 _display.write(charIndex);
-{% endhighlight C++ %}
+```
 
 Here's an [example](https://github.com/makeabilitylab/arduino/blob/master/OLED/DrawChar/DrawChar.ino) iterating through all of the glyphs individually, which demonstrates the code above. You can use either `drawChar` or `write`—we demonstrate both in [DrawChar.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/DrawChar/DrawChar.ino).
 
@@ -510,7 +510,7 @@ First, to get a feel for the Adafruit GFX API and the coordinate system, let's s
 
 Remember, in `loop()`, you need to:
 
-{% highlight C++ %}
+```cpp
 // Clear the display. If we don't do this, we'll simply be drawing over our
 // previous renderings (which you may sometimes want but generally not)
 _display.clearDisplay();
@@ -520,7 +520,7 @@ drawStuff();
 
 // Render graphics buffer to screen
 _display.display();
-{% endhighlight C++ %}
+```
 
 We made a version called [SimpleDrawingDemo.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/SimpleDrawingDemo/SimpleDrawingDemo.ino) that draws shapes of random sizes and locations on **each frame**, but you could do something even simpler (or more complex)!
 
@@ -574,7 +574,7 @@ For the C++ implementation using the Adafruit GFX library and Arduino, the key b
 
 Again, rather than, say, "miles per hour" or "pixels per second", we've defined speed as "pixels per frame"—that is, how many pixels does the object move per frame. If we set `_xSpeed` to 5 and `_ySpeed` to 0, then the ball would move 5 pixels in x per frame (and simply bounce back and forth from the left side of the screen to the right and back again).
 
-{% highlight C++ %}
+```cpp
 // Create the display object
 Adafruit_SSD1306 _display(128, 64, &Wire, 4);
 
@@ -619,7 +619,7 @@ void loop() {
   // Render buffer to screen
   _display.display();
 }
-{% endhighlight C++ %}
+```
 
 You can view the full code on GitHub as [BallBounce.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/BallBounce/BallBounce.ino). 
 
@@ -659,7 +659,7 @@ Here's the circuit. Same as before but we've added a 10K potentiometer.
 
 The code is simple: read the analog input and use it to set the circle's radius.
 
-{% highlight C++ %}
+```cpp
 void loop() {
   // On each loop, we'll want to clear the display so we're not writing over
   // previously drawn data
@@ -686,7 +686,7 @@ void loop() {
 
   delay(50);
 }
-{% endhighlight C++ %}
+```
 
 You can view the full code on GitHub as [AnalogBallSize.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogBallSize/AnalogBallSize.ino).
 
@@ -706,7 +706,7 @@ Now let's hook up **two** analog inputs to control the x,y location of the circl
 
 For the code, it's very similar to [AnalogBallSize.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogBallSize/AnalogBallSize.ino), but we translate the `analogRead` values to x and y locations: 
 
-{% highlight C++ %}
+```cpp
 void loop() {
   // On each loop, we'll want to clear the display so we're not writing over
   // previously drawn data
@@ -729,7 +729,7 @@ void loop() {
 
   delay(50);
 }
-{% endhighlight C++ %}
+```
 
 You can view the full code on GitHub as [AnalogBallLocation.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogBallLocation/AnalogBallLocation.ino).
 
@@ -749,7 +749,7 @@ The idea is simple: read in a sensor value as `sensorVal`, draw a vertical line 
 
 Notably, this code takes advantage of **selectively** calling `_display.clearDisplay()`. Unlike the other examples we've shared thus far—which clear the display on each frame—here, we take advantage of graphics persisting across `_display.display()` calls to "build up" our graph over time. That is, we only draw **one** new line per new sensor input, which persists on the screen until `_xPos >= _display.width()`, at which point we call `_display.clearDisplay()`.
 
-{% highlight C++ %}
+```cpp
 void loop() {
 
   // Read the analog voltage value
@@ -773,7 +773,7 @@ void loop() {
 
   delay(10);
 }
-{% endhighlight C++ %}
+```
 
 The full source code is available in our [OLED GitHub](https://github.com/makeabilitylab/arduino/tree/master/OLED) as [AnalogGraph.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogGraph/AnalogGraph.ino). Here's a video demo:
 
@@ -789,7 +789,7 @@ A slightly improved but more complicated version of the analog graph is a **scro
 
 Look over the code. Does it make sense? 
 
-{% highlight C++ %}
+```cpp
 int _circularBuffer[SCREEN_WIDTH]; //fast way to store values 
 int _curWriteIndex = 0; // tracks where we are in the circular buffer
 
@@ -827,7 +827,7 @@ void loop() {
   
   delay(10);
 }
-{% endhighlight C++ %}
+```
 
 The full source code is available in our [OLED GitHub](https://github.com/makeabilitylab/arduino/tree/master/OLED) as [AnalogGraphScrolling.ino](https://github.com/makeabilitylab/arduino/blob/master/OLED/AnalogGraphScrolling/AnalogGraphScrolling.ino). Here's a video demo. 
 

--- a/advancedio/servo.md
+++ b/advancedio/servo.md
@@ -137,7 +137,7 @@ The [Arduino Servo library](https://github.com/arduino-libraries/Servo/blob/mast
 
 ### Key API
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h>
 
 Servo myServo;              // Create a Servo object
@@ -146,7 +146,7 @@ void setup() {
   myServo.attach(3);        // Attach to pin 3 (any digital pin works)
   myServo.write(90);        // Move to 90° (center position)
 }
-{% endhighlight C++ %}
+```
 
 Here are the most commonly used functions:
 
@@ -188,7 +188,7 @@ If you visit the [GitHub source tree for the Servo library](https://github.com/a
 
 If you look at [Servo.h](https://github.com/arduino-libraries/Servo/blob/master/src/Servo.h), you'll see how the library selects the right implementation:
 
-{% highlight C++ %}
+```cpp
 #if defined(ARDUINO_ARCH_AVR)
 #include "avr/ServoTimers.h"
 #elif defined(ARDUINO_ARCH_SAM)
@@ -200,7 +200,7 @@ If you look at [Servo.h](https://github.com/arduino-libraries/Servo/blob/master/
 #else
 #error "This library only supports boards with an AVR, SAM, SAMD, NRF52..."
 #endif
-{% endhighlight C++ %}
+```
 
 Servo libraries rely heavily on hardware timers. Since an Arduino Uno (AVR) and a Nano 33 IoT (SAMD) have completely different timer hardware, the library must maintain separate codebases for each. If you look inside the `avr` folder, you'll find custom [Servo.cpp](https://github.com/arduino-libraries/Servo/blob/master/src/avr/Servo.cpp) and [ServoTimers.h](https://github.com/arduino-libraries/Servo/blob/master/src/avr/ServoTimers.h) code specifically written to manipulate ATmega registers—this is why the Servo library "claims" Timer1 and disables `analogWrite()` on certain pins, as noted above.
 
@@ -264,7 +264,7 @@ Now that we understand how servos work and have one wired up, let's build some p
 
 Just as we started with [blinking an LED](../arduino/led-blink.md) and [lighting up NeoPixels](addressable-leds.md#activity-1-light-em-up), let's start with the simplest possible servo program: sweeping back and forth between 0° and 180°. This confirms your wiring is correct and that the library is communicating with the servo.
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h>
 
 const int SERVO_PIN = 3;
@@ -287,7 +287,7 @@ void loop() {
     delay(15);
   }
 }
-{% endhighlight C++ %}
+```
 
 <!-- TODO: Record a video of the servo sweeping back and forth and embed here. The Tinkercad version is here: https://www.tinkercad.com/things/hNVrJEXGKrT-simple-servo-sweep -->
 
@@ -313,7 +313,7 @@ Use the same servo wiring as before, and add a 10KΩ potentiometer with its wipe
 
 #### The code
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h>
 
 const int SERVO_PIN = 3;
@@ -344,7 +344,7 @@ void loop() {
 
   delay(15);
 }
-{% endhighlight C++ %}
+```
 
 <!-- TODO: Record a video of the potentiometer controlling the servo and embed here -->
 
@@ -384,7 +384,7 @@ Use the same servo + potentiometer wiring, and add two tactile buttons on Pins 8
 
 #### The code
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h>
 
 const int SERVO_PIN = 3;
@@ -452,7 +452,7 @@ void loop() {
 
   delay(15);
 }
-{% endhighlight C++ %}
+```
 
 <!-- TODO: Record a video of the gauge in action and embed here. Consider 3D printing or crafting a simple gauge face/backing to make the servo look like an analog meter. -->
 

--- a/advancedio/smoothing-input.md
+++ b/advancedio/smoothing-input.md
@@ -119,7 +119,7 @@ Below, we compute three different moving average filter window sizes: 5, 10, and
 
 The official Arduino [signal smoothing tutorial](https://www.arduino.cc/en/Tutorial/BuiltInExamples/Smoothing) uses a moving average filter. Cleverly, their code uses an optimization (which we borrow below) to avoid iterating over the entire window to compute each new average. Instead, we simply subtract the least recent reading in our sliding window from a running total. The code also uses a [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer) to eliminate needless memory allocations, which is important on constrained systems like microcontrollers.
 
-{% highlight C %}
+```cpp
 
 // read the sensor value
 int sensorVal = analogRead(SENSOR_INPUT_PIN);
@@ -144,7 +144,7 @@ if (_curReadIndex >= SMOOTHING_WINDOW_SIZE) {
   // ...wrap around to the beginning:
   _curReadIndex = 0;
 }
-{% endhighlight C %}
+```
 
 #### Arduino code
 
@@ -227,7 +227,7 @@ The coefficient $$\alpha$$ determines the exponential dropoff. A higher $$\alpha
 
 If you're not used to reading equations, then perhaps the Arduino code below is more clear. The algorithm is quite straightforward and, again, unlike the traditional moving average algorithm, does not require a window buffer!
 
-{% highlight C %}
+```cpp
 const int SENSOR_INPUT_PIN = A0;
 
 float _ewmaAlpha = 0.1;  // the EWMA alpha value (α)
@@ -251,7 +251,7 @@ void loop()
   Serial.println(_ewma);  
   delay(50); // Reading new values at ~20Hz
 }
-{% endhighlight C %}
+```
 
 **Code.** [This code](https://github.com/makeabilitylab/arduino/blob/master/Filters/ExponentialWeightedMovingAverageFilter/ExponentialWeightedMovingAverageFilter.ino) is on GitHub.
 {: .fs-1 }

--- a/advancedio/vibromotor.md
+++ b/advancedio/vibromotor.md
@@ -378,7 +378,7 @@ Now that we understand the theory and have our circuit wired up, let's build thr
 
 Just as we started our Arduino journey by [blinking an LED](../arduino/led-blink.md), let's start here by "blinking" a vibration motor—turning it on and off at a regular interval. This is the simplest possible vibromotor program and confirms that your circuit is working.
 
-{% highlight C++ %}
+```cpp
 const int VIBRO_PIN = 3; // Connect to the transistor base (via 1K resistor)
 
 void setup() {
@@ -391,7 +391,7 @@ void loop() {
   digitalWrite(VIBRO_PIN, LOW);   // Motor off
   delay(500);                     // Pause for 500ms
 }
-{% endhighlight C++ %}
+```
 
 Try experimenting with different on/off durations. What happens with very short pulses (*e.g.,* 50ms on, 200ms off)? Can you feel the difference between a 100ms buzz and a 500ms buzz? This is the foundation of haptic pattern design!
 
@@ -407,7 +407,7 @@ Use the same transistor circuit as before, and add a 10KΩ potentiometer with it
 
 #### The code
 
-{% highlight C++ %}
+```cpp
 const int VIBRO_PIN = 3;           // PWM pin connected to transistor base
 const int POT_PIN = A0;            // Potentiometer wiper
 const int MAX_ANALOG_INPUT = 1023; // 10-bit ADC
@@ -435,7 +435,7 @@ void loop() {
 
   delay(50);
 }
-{% endhighlight C++ %}
+```
 
 As you turn the potentiometer, you should feel the vibration intensity change smoothly from off (fully counter-clockwise) to maximum (fully clockwise). Open the Serial Monitor to see the mapping from analog input to PWM output. Can you feel differences at low PWM values (*e.g.,* between 20 and 50)? At what PWM value does the motor stop vibrating entirely?
 
@@ -453,7 +453,7 @@ Use the same transistor + vibromotor circuit, and add three tactile buttons conn
 
 #### The code
 
-{% highlight C++ %}
+```cpp
 const int VIBRO_PIN = 3;
 const int BTN_TAP = 8;
 const int BTN_ALERT = 9;
@@ -506,7 +506,7 @@ void playAlarm() {
   }
   delay(300);
 }
-{% endhighlight C++ %}
+```
 
 Try pressing each button and feeling the difference. Can you tell the three patterns apart with your eyes closed? Try designing your own patterns—a heartbeat (*thump-thump... thump-thump...*), a countdown, or a rhythmic pattern. Haptic design is all about creating distinct, recognizable tactile signatures.
 

--- a/arduino/buttons.md
+++ b/arduino/buttons.md
@@ -183,7 +183,7 @@ However, if you do this, what will the digital input pin read when the switch is
 
 In fact, try wiring up this configuration yourself and running the following program with the [Serial Monitor](serial-print.md#step-3-open-serial-monitor-in-the-arduino-ide) open. What happens when you press the button? Try touching the button legs with your fingers but not actually pressing the button—what happens to the `digitalRead` value? Are you reliably tracking the button state?
 
-{% highlight cpp %}
+```cpp
 const int INPUT_BUTTON_PIN = 2;
 void setup()
 {
@@ -197,7 +197,7 @@ void loop()
   Serial.println(buttonVal);                     // print value to Serial
   delay(5);                                      // small delay
 }
-{% endhighlight cpp %}
+```
 
 Here's a quick video demonstration of what happens—the floating pin problem! Note: we are using a slightly modified version of this code where an LED is turned on if the button is pressed (*i.e.,* if `buttonVal == 1`). This just makes it easier to see the fluctuating button state.
 
@@ -374,7 +374,7 @@ To zoom in on this image, right-click and select 'Open image in a new tab.'
 
 ### Code to turn on LED with button press
 
-{% highlight cpp %}
+```cpp
 const int INPUT_BUTTON_PIN = 2;
 const int OUTPUT_LED_PIN = LED_BUILTIN;
 
@@ -391,7 +391,7 @@ void loop()
   digitalWrite(OUTPUT_LED_PIN, buttonState);
   delay(30);
 }
-{% endhighlight cpp %}
+```
 
 ### Tinkercad version with no breadboard
 

--- a/arduino/debouncing.md
+++ b/arduino/debouncing.md
@@ -150,7 +150,7 @@ For our first and most basic solution, we will read the button state, wait a giv
 
 We're going to use [`delay`](https://www.arduino.cc/reference/en/language/functions/time/delay/) here to wait for the "debouncing window" time period, which we already know should generally be avoided but is sometimes helpful and appropriate (if it's not negatively impacting the responsiveness of your program, for example).
 
-{% highlight cpp %}
+```cpp
 
 const int BUTTON_INPUT_PIN = 2;
 const int LED_OUTPUT_PIN = 3;
@@ -186,7 +186,7 @@ void loop() {
   // Write out HIGH or LOW
   digitalWrite(LED_OUTPUT_PIN, _savedButtonVal);
 }
-{% endhighlight cpp %}
+```
 
 This [source code](https://github.com/makeabilitylab/arduino/blob/master/Basics/digitalRead/DebounceWithDelays/DebounceWithDelays.ino) is on GitHub.
 {: .fs-1 }
@@ -235,7 +235,7 @@ This solution is nicely captured by user [cdvma](https://www.reddit.com/r/embedd
 
 Here's a quick implementation:
 
-{% highlight cpp %}
+```cpp
 
 const int BUTTON_INPUT_PIN = 2;
 const int LED_OUTPUT_PIN = 3;
@@ -267,7 +267,7 @@ void loop() {
   // Write out HIGH or LOW
   digitalWrite(LED_OUTPUT_PIN, _savedButtonVal);
 }
-{% endhighlight cpp %}
+```
 
 This solution is less robust but works well for human input in environments with limited electrical noise (see this [Reddit discussion](https://www.reddit.com/r/embedded/comments/gf74p8/reliable_user_input_with_unreliable_physical/fprrygg?utm_source=share&utm_medium=web2x&context=3)). However, as is pointed out in the Reddit thread ([link](https://www.reddit.com/r/embedded/comments/gf74p8/reliable_user_input_with_unreliable_physical/fpw7xpf?utm_source=share&utm_medium=web2x&context=3)), this simple solution does not protect against electrostatic discharge (ESD) and thus fails regulatory requirements (which require the two state reads like we did in Solutions 1 and 2).
 

--- a/arduino/fast-analog-read.md
+++ b/arduino/fast-analog-read.md
@@ -38,7 +38,7 @@ This [blog post ](http://yaab-arduino.blogspot.com/2015/02/fast-sampling-from-an
 
 Inspired by the discussion on this [Sparkfun blog post](https://learn.sparkfun.com/blog/1687#comments), I looked up the source code directly to investigate. The entire `int main(void)` function in [main.cpp](https://github.com/arduino/ArduinoCore-avr/blob/2f67c916f6ab6193c404eebe22efe901e0f9542d/cores/arduino/main.cpp) is:
 
-```C
+```cpp
 int main(void)
 {
     init();
@@ -64,7 +64,7 @@ From this [Arduino forum post](https://forum.arduino.cc/index.php?topic=4324.msg
 
 You can also manipulate the ports directly rather than via the Arduino libraries (which incur lots of overhead). From the same forum post:
 
-```C
+```cpp
 cli();
  while (1) {
    PORTD |= B1000;

--- a/arduino/force-sensitive-resistors.md
+++ b/arduino/force-sensitive-resistors.md
@@ -203,11 +203,11 @@ If, instead, we can't assume that both ranges start at zero, the more general co
 
 This type of range conversion is so common that Arduino (and Processing and many other programming libraries) have a built-in function for it called [`map`](https://www.arduino.cc/reference/en/language/functions/math/map/). It's called "map" because we want to re-map a number from one range to another. Indeed, here's the entire `map` function from the Arduino source code—notice it also multiplies before dividing:
 
-{% highlight cpp %}
+```cpp
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
-{% endhighlight cpp %}
+```
 
 Importantly, as the [docs](https://www.arduino.cc/reference/en/language/functions/math/map/) make abundantly clear, notice that this built-in method uses **integer** math and so will not return fractions (floats). If you need more precise conversions, implement your own mapping function (which also provides the opportunity to implement non-linear conversions like logarithmic mappings). 
 

--- a/arduino/inside-arduino.md
+++ b/arduino/inside-arduino.md
@@ -32,7 +32,7 @@ Here are some common answers. Note: I have not stress tested them all and I'm su
 
 **First**, perhaps the simplest way is to cast everything as a String and use string concatenation:
 
-``` C
+```cpp
 Serial.println((String)"Var 1:" + var1 + " Var 2:" + var2 + " Var 3:" + var3);
 ```
 [Source](https://arduino.stackexchange.com/a/69566)
@@ -42,11 +42,11 @@ Note: you should only do this for rapid prototypes because of memory inefficienc
 
 **Second**, use `snprintf` to format into a character buffer. This is the standard C/C++ approach and avoids the memory fragmentation problems of the `String` class:
 
-{% highlight cpp %}
+```cpp
 char buffer[64]; // make sure this is large enough for your formatted string
 snprintf(buffer, sizeof(buffer), "Var 1: %d  Var 2: %d  Var 3: %d", var1, var2, var3);
 Serial.println(buffer);
-{% endhighlight cpp %}
+```
 
 {: .note }
 > On standard Arduino AVR boards, `snprintf` does **not** support floating-point format specifiers (`%f`) out of the box—this is disabled to save memory. To format floats, use [`dtostrf()`](https://www.nongnu.org/avr-libc/user-manual/group__avr__stdlib.html#ga060c998e77fb5fc0d3168b3ce8571571) to convert the float to a string first, then include it in your `snprintf` call.
@@ -55,7 +55,7 @@ Serial.println(buffer);
 
 **Fourth**, you could redirect `printf` to Serial output:
 
-{% highlight cpp %}
+```cpp
 // Function that printf and related will use to print
 int serial_putchar(char c, FILE* f) {
     if (c == '\n') serial_putchar('\r', f);
@@ -81,7 +81,7 @@ void loop() {
     delay(1);    
   }
 }
-{% endhighlight cpp %}
+```
 [Source](https://arduino.stackexchange.com/a/480) and [discussion](https://forum.arduino.cc/index.php/topic,120440.0.html)
 
 ## What's calling loop() and how fast?
@@ -90,7 +90,7 @@ Because Arduino is [open source](https://github.com/arduino), we can look up the
 
 In short, `loop()` is called within an infinite `for` (or `while` loop). The only overhead is checking for whether there is data available on the serial port and then reading the serial buffers. The entire `int main(void)` function in [main.cpp](https://github.com/arduino/ArduinoCore-avr/blob/2f67c916f6ab6193c404eebe22efe901e0f9542d/cores/arduino/main.cpp) is:
 
-{% highlight cpp %}
+```cpp
 int main(void)
 {
     init();
@@ -108,11 +108,11 @@ int main(void)
     }
     return 0;
 }
-{% endhighlight cpp %}
+```
 
 Interestingly, this [Arduino forum post](https://forum.arduino.cc/index.php?topic=615714.0) suggests that because `serialEventRun()` is weakly defined in the core, you can define it locally in your sketch to override the default definition, which, according to the OP, will "save a little memory and makes the loop() run a little faster too!" You can do this if you don't need to use serial communication.
 
-{% highlight cpp %}
+```cpp
 void serialEventRun() {}
 
 void setup() {
@@ -120,7 +120,7 @@ void setup() {
 
 void loop() {
 }
-{% endhighlight cpp %}
+```
 
 ## Converting analogRead to voltages
 
@@ -161,7 +161,7 @@ As you might expect—given our warnings about avoiding overuse of [`delay(unsig
 
 The [`delay(unsigned long ms)`](https://www.arduino.cc/reference/en/language/functions/time/delay/) function is found in [wiring.c](https://github.com/arduino/ArduinoCore-avr/blob/2f67c916f6ab6193c404eebe22efe901e0f9542d/cores/arduino/wiring.c) and is, in its entirety, copied below:
 
-{% highlight cpp %}
+```cpp
 void delay(unsigned long ms)
 {
   uint32_t start = micros();
@@ -174,7 +174,7 @@ void delay(unsigned long ms)
     }
   }
 }
-{% endhighlight cpp %}
+```
 
 ## How does `digitalWrite()` work internally?
 
@@ -228,7 +228,7 @@ If you bypass the Arduino framework entirely, you can write code directly for th
 
 Here is what a standard "Blinky" sketch looks like in bare-metal C for the **Arduino Uno** (ATmega328P). On the Uno, the built-in LED (Pin 13) is hardwired to bit 5 of Port B (`PB5`). According to Section 13.2.1 of the ATmega328P datasheet, the `DDxn` bit in the Data Direction Register (`DDRx`) selects the pin's direction, and the `PORTxn` bit in the Data Register sets the output logic level.
 
-{% highlight cpp %}
+```cpp
 #ifndef F_CPU
 #define F_CPU 16000000UL // 16 MHz clock speed
 #endif
@@ -252,11 +252,11 @@ int main(void) {
     // never reached
     return 0; 
 }
-{% endhighlight cpp %}
+```
 
 If we want to run this exact same bare-metal Blinky on an **Arduino Leonardo** (ATmega32U4), the code has to change. Because of the Leonardo's internal USB hardware, the built-in LED (Pin 13) is wired to bit 7 of Port C (`PC7`). 
 
-{% highlight cpp %}
+```cpp
 #ifndef F_CPU
 #define F_CPU 16000000UL
 #endif
@@ -278,7 +278,7 @@ int main(void) {
     // never reached
     return 0;
 }
-{% endhighlight cpp %}
+```
 
 ### The Takeaway: Hardware Abstraction
 

--- a/arduino/led-blink.md
+++ b/arduino/led-blink.md
@@ -159,24 +159,24 @@ Start a new sketch in the Arduino IDE:
 
 Because the 20 digital I/O pins can be used for **either** **input** or **output**, we need to specify that Pin 3 should be used for *output*. That is, we want the Arduino to **output** a 5V signal on Pin 3 to turn on our LED. We configure pins in the  `setup()` block and use the [`pinMode(int pin, int mode)`](https://www.arduino.cc/reference/en/language/functions/digital-io/pinmode/) command, which takes in a pin as the first parameter and a mode (`INPUT` or `OUTPUT`) as the second.
 
-{% highlight C %}
+```cpp
 void setup() {
   // put your setup code here, to run once:
   pinMode(3, OUTPUT);
 }
-{% endhighlight C %}
+```
 
 ### Step 3: Set Pin 3 HIGH
 
 Lastly, we need to actually set the Pin 3 signal to `HIGH`. For this, we use the  [`digitalWrite(int pin, int value)`](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalwrite/) command, which takes in a pin as the first parameter and a value (`HIGH` or `LOW`) as the second. We could do this either in `setup()` or in `loop()` but since we're not currently changing the output signal, there is no reason to put it in `loop()`, so let's put it in `setup()` along with the `pinMode` code.
 
-{% highlight C %}
+```cpp
 void setup() {
   // put your setup code here, to run once:
   pinMode(3, OUTPUT);
   digitalWrite(3, HIGH); // turn LED on (output 5V)
 }
-{% endhighlight C %}
+```
 
 ### Step 4: Compile the code
 
@@ -212,7 +212,7 @@ Now, let's modify our code to turn on *and* off the LED programmatically. More s
 
 First, move the digitalWrite code from `setup()` to `loop()`:
 
-{% highlight C %}
+```cpp
 void setup() {
   // set Pin 3 to output
   pinMode(3, OUTPUT);
@@ -221,13 +221,13 @@ void setup() {
 void loop() {
   digitalWrite(3, HIGH);  // turn LED on (output 5V)
 }
-{% endhighlight C %}
+```
 
 ### Step 2: Add in delays and code to turn off LED
 
 Now, add in code to pause (for one second) and then turn off the LED (for one second) using `delay()`. Remember, when `loop()` completes, it is automatically called again (making the LED blink continuously).
 
-{% highlight C %}
+```cpp
 void setup() {
   // set Pin 3 to output
   pinMode(3, OUTPUT);
@@ -239,7 +239,7 @@ void loop() {
   digitalWrite(3, LOW);   // turn LED off (output 0V)
   delay(1000);            // wait another second
 }
-{% endhighlight C %}
+```
 
 ### Step 3: Compile and upload
 
@@ -253,7 +253,7 @@ We're done! Now, compile and upload the code and see it run!
 
 Typically, we want to limit the use of *literal constants* in our code and replace them by variables. In this case, let's replace `3` with `LED_OUTPUT_PIN` defined as a global variable at the top of our program (`const int LED_OUTPUT_PIN = 3;`). This will make our code more maintainable, more readable, and less prone to accidental mistakes. Try to do this for all literals in the future.
 
-{% highlight C %}
+```cpp
 const int LED_OUTPUT_PIN = 3;
 void setup() {
   // set Pin 3 to output
@@ -266,7 +266,7 @@ void loop() {
   digitalWrite(LED_OUTPUT_PIN, LOW);   // turn LED off (output 0V)
   delay(1000);                         // wait another second
 }
-{% endhighlight C %}
+```
 
 ### Walking through the code
 
@@ -347,7 +347,7 @@ Because `delay()` usage can be so troublesome, as part of their introductory tut
 
 To avoid `delay()` calls, the code tracks **time**, **LED state changes** (when the LED switches from `HIGH` to `LOW` or `LOW` to `HIGH`), and **when** these state changes occur. The [BlinkWithoutDelay](https://www.arduino.cc/en/Tutorial/BlinkWithoutDelay) main loop is below. Notice that there are no `delay()` calls!
 
-{% highlight C %}
+```cpp
 void loop() {
   // check to see if it's time to blink the LED; that is, if the difference
   // between the current time and last time you blinked the LED is bigger than
@@ -369,7 +369,7 @@ void loop() {
     digitalWrite(ledPin, ledState);
   }
 }
-{% endhighlight C %}
+```
 
 We've also made our own [BlinkWithoutDelay](https://github.com/makeabilitylab/arduino/blob/master/Basics/digitalWrite/BlinkWithoutDelay/BlinkWithoutDelay.ino) version, which is available on [GitHub](https://github.com/makeabilitylab/arduino/blob/master/Basics/digitalWrite/BlinkWithoutDelay/BlinkWithoutDelay.ino) and shown below. This version is functionally equivalent to Arduino's official example but uses our own coding style and is, in our opinion, more understandable.
 

--- a/arduino/led-blink2.md
+++ b/arduino/led-blink2.md
@@ -83,7 +83,7 @@ Let's write the code!
 
 ### Step 1: Write the setup and initialization code
 
-{% highlight C %}
+```cpp
 const int LED1_OUTPUT_PIN = 3; // Anode faces Pin 3 (cathode connected to 0V)
 const int LED2_OUTPUT_PIN = 4; // Cathode faces Pin 4 (anode connected to 5V)
 const int DELAY_MS = 1000; // delay for 1 sec between blinks
@@ -94,11 +94,11 @@ void setup() {
   pinMode(LED1_OUTPUT_PIN, OUTPUT);
   pinMode(LED2_OUTPUT_PIN, OUTPUT);
 }
-{% endhighlight C %}
+```
 
 ### Step 2: Write the blink code in loop()
 
-{% highlight C %}
+```cpp
 // The loop function runs over and over again forever
 void loop() {
   // Below, you're going to see that driving Pin 3 HIGH will turn on LED1
@@ -111,7 +111,7 @@ void loop() {
   digitalWrite(LED2_OUTPUT_PIN, LOW);   // turns ON LED2 (Pin 4 is now 0V and other leg of LED is 5V)
   delay(DELAY_MS);                      // wait for a second
 }
-{% endhighlight C %}
+```
 
 ### Step 3: Compile, upload, and run the code!
 

--- a/arduino/led-blink3.md
+++ b/arduino/led-blink3.md
@@ -31,7 +31,7 @@ As with our previous lesson on [crossfading RGB LEDs](rgb-led-fade.md), this les
 
 The canonical and beloved **first Arduino sketch**, [Blink](https://www.arduino.cc/en/tutorial/blink), enables beginners to quickly build and write code for a circuit. The code looks something like this, which we covered in our own [Blink lesson](led-blink.md):
 
-{% highlight C %}
+```cpp
 void setup() {
   // set Pin 3 to output
   pinMode(3, OUTPUT);
@@ -43,7 +43,7 @@ void loop() {
   digitalWrite(3, LOW);   // turn LED off (output 0V)
   delay(1000);            // wait another second
 }
-{% endhighlight C %}
+```
 
 Blink is easy. It's gratifying. But... it sets up a flawed mental model about how to structure programs and when/how to use [`delay()`](https://www.arduino.cc/reference/en/language/functions/time/delay/).
 
@@ -94,7 +94,7 @@ For our initial approach, we need four things for each LED:
 
 For the **blink interval**, we'll use `const` variables like `LED1_BLINK_INTERVAL_MS`, `LED2_BLINK_INTERVAL_MS`, and `LED3_BLINK_INTERVAL_MS`
 
-{% highlight C %}
+```cpp
 const int LED1_OUTPUT_PIN = 2;
 const int LED1_BLINK_INTERVAL_MS = 200; // interval at which to blink LED1 (in milliseconds)
 
@@ -103,13 +103,13 @@ const int LED2_BLINK_INTERVAL_MS = 333; // interval at which to blink LED2 (in m
 
 const int LED3_OUTPUT_PIN = 9;
 const int LED3_BLINK_INTERVAL_MS = 1111; // interval at which to blink LED3 (in milliseconds)
-{% endhighlight C %}
+```
 
 #### Toggle timestamps and LED states
 
 For the **toggle timestamps** and **LED states**, we'll use variables like `_led1LastToggledTimestampMs` and `_led1State`. We can toggle `ledState` simply by: `ledState = !ledState`.
 
-{% highlight C %}
+```cpp
 unsigned long _led1LastToggledTimestampMs = 0; // tracks the last time LED1 was updated
 int _led1State = LOW; // will toggle between LOW and HIGH
 
@@ -118,7 +118,7 @@ int _led2State = LOW; // will toggle between LOW and HIGH
 
 unsigned long _led3LastToggledTimestampMs = 0; // tracks the last time LED3 was updated
 int _led3State = LOW; // will toggle between LOW and HIGH
-{% endhighlight C %}
+```
 
 To capture timestamps, we'll use Arduino's [`millis()` ](https://www.arduino.cc/reference/en/language/functions/time/millis/) function, which returns "*the number of **milliseconds** passed since the Arduino board began running the current program*" as an `unsigned long`. 
 
@@ -128,7 +128,7 @@ On the Arduino, the `unsigned long` data type is 32 bits (4 bytes), which ranges
 
 We then use the same general logic as the "blinking without delays" [covered previously](led-blink.md#blink-without-using-delay) for each LED:
 
-{% highlight C %}
+```cpp
 unsigned long currentTimestampMs = millis();
 
 // Check to see if we reached the toggle state interval for LED1 
@@ -146,7 +146,7 @@ if (currentTimestampMs - _led2LastToggledTimestampMs >= LED2_BLINK_INTERVAL_MS) 
 }
 
 ... // and so on, copy the above block of code for each LED you're trying to blink
-{% endhighlight C %}
+```
 
 #### Tracking timestamps and overflow
 
@@ -158,7 +158,7 @@ Great question! And yes, it will still work! And the reason is because we are us
 
 For example, imagine that `_lastToggledTimestampMs` is `4,294,967,290` or `0xFFFFFFFA` in hexadecimal (32 bits), which is 5 milliseconds from overflow. And then imagine that `millis()` overflows (returns back to 0) and `currentTimestampMs` becomes, say, `1` or `0x00000001`. So, our subtraction is then: `0x00000001 - 0xFFFFFFFA`. There is `7` milliseconds difference between these two numbers, so we'd like the subtraction to result in `7`:
 
-```
+```text
 1. 0xFFFFFFFA
 2. 0xFFFFFFFB
 3. 0xFFFFFFFC
@@ -171,7 +171,7 @@ For example, imagine that `_lastToggledTimestampMs` is `4,294,967,290` or `0xFFF
 
 And this is what we get! Feel free to experiment with this yourself by running the code below on you Arduino. We also suggest [this article](https://www.baldengineer.com/arduino-millis-plus-addition-does-not-add-up.html) by James Lewis about `millis()`, overflow, and arithmetic for more background.  
 
-{% highlight C %}
+```cpp
 unsigned long _lastToggledTimestampMs = 4294967290; // change this to experiment with overflow
 
 void setup() {
@@ -194,7 +194,7 @@ void loop() {
 
   _lastToggledTimestampMs++;
 }
-{% endhighlight C %}
+```
 
 #### The full code for multi-rate blinking
 
@@ -222,7 +222,7 @@ We're going to define a new class, called `Blinker`, which will greatly simplify
 
 Once we've made the `Blinker` class, our main code reduces to:
 
-{% highlight C++ %}
+```cpp
 Blinker _led1Blinker(2, 200);  // specify pin and blink interval (200ms)
 Blinker _led2Blinker(5, 333);  // specify pin and blink interval (333ms)
 Blinker _led3Blinker(9, 1111); // specify pin and blink interval (1111ms)
@@ -238,7 +238,7 @@ void loop() {
   _led2Blinker.update();
   _led3Blinker.update();
 }
-{% endhighlight C++ %}
+```
 
 But we have to make the `Blinker` class first, which we do below!
 
@@ -254,7 +254,7 @@ To build our Blinker class, recall that we need four things per LED:
 
 For the `Blinker` class, we are simply going to convert these four things into member variables:
 
-{% highlight C++ %}
+```cpp
 class Blinker{
 
   private:
@@ -265,11 +265,11 @@ class Blinker{
     unsigned long _lastToggledTimestamp; // last state toggle in ms
 
   ... // more here
-{% endhighlight C++ %}
+```
 
 Finally, we need two functions: a `constructor` and `update()`—the latter which handles our core logic and toggling code and is intended to be called once per `loop()` iteration. We are going to declare these in the class definition itself:
 
-{% highlight C++ %}
+```cpp
   public: 
     // Constructor
     Blinker(int pin, unsigned long blinkInterval) :
@@ -293,7 +293,7 @@ Finally, we need two functions: a `constructor` and `update()`—the latter whic
         digitalWrite(_pin, _state);
       }
     }
-{% endhighlight C++ %}
+```
 
 In order to use the `Blinker` class (as shown above), it needs to be defined within your `.ino` sketch at the top of the file (before you try to instantiate a Blinker object). Later, we'll also show how to create a class that exists in its own `.h` and `.cpp` files.
 

--- a/arduino/led-fade.md
+++ b/arduino/led-fade.md
@@ -129,7 +129,7 @@ Start a new sketch in the Arduino IDE:
 
 Our initialization code is the same as for [LED blink](led-blink.md) except for the addition of `const int MAX_ANALOG_OUT = 255;` and a constant for the delay amount of 5 milliseconds (`const int DELAY_MS = 5;`).
 
-{% highlight C %}
+```cpp
 const int LED_OUTPUT_PIN = 3;
 const int MAX_ANALOG_OUT = 255; // the max analog output on the Uno is 255
 const int DELAY_MS = 5;
@@ -138,13 +138,13 @@ void setup() {
   // set Pin 3 to output
   pinMode(LED_OUTPUT_PIN, OUTPUT);
 }
-{% endhighlight C %}
+```
 
 ### Step 3: Write fade loop
 
 Now, write code that outputs steadily increasing values for [`analogWrite`](https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/) (to fade on) followed by steadily decreasing values (to fade off).
 
-{% highlight C %}
+```cpp
 void loop(){
   // fade on
   for(int i = 0; i <= MAX_ANALOG_OUT; i += 1){
@@ -158,7 +158,7 @@ void loop(){
     delay(DELAY_MS);
   }
 }
-{% endhighlight C %}
+```
 
 The full code is embedded below:
 
@@ -234,7 +234,7 @@ So, let's rewrite the fade example but without for loops and, instead, rely on t
 {: .note }
 > I have a habit of prefixing my global variables by `_` but this is just my own convention and helps me easily discern between local variables and global variables. You need not do this, of course! 😊
 
-{% highlight C %}
+```cpp
 const int LED_OUTPUT_PIN = 3;
 const int MAX_ANALOG_OUT = 255; // the max analog output on the Uno is 255
 const int DELAY_MS = 5;
@@ -266,7 +266,7 @@ void loop() {
   // wait for some milliseconds to see the dimming effect
   delay(DELAY_MS);
 }
-{% endhighlight C %}
+```
 
 You can find [this code in GitHub](https://github.com/makeabilitylab/arduino/blob/master/Basics/analogWrite/FadeOnAndOff/FadeOnAndOff.ino).
 

--- a/arduino/piano.md
+++ b/arduino/piano.md
@@ -90,7 +90,7 @@ The code is fairly straightforward.
 
 First, let's declare the waveform frequencies of our notes.
 
-{% highlight cpp %}
+```cpp
 // Frequencies (in Hz) of our piano keys
 // From: https://en.wikipedia.org/wiki/Piano_key_frequencies
 #define KEY_C 262  // 261.6256 Hz (middle C)
@@ -98,7 +98,7 @@ First, let's declare the waveform frequencies of our notes.
 #define KEY_E 330  // 329.6276 Hz
 #define KEY_F 349  // 349.2282 Hz
 #define KEY_G 392  // 391.9954 Hz
-{% endhighlight cpp %}
+```
 
 #### Step 2: Declare our pin constants
 
@@ -106,7 +106,7 @@ Our piano has **five** buttons, so we need five input pins. We also need an outp
 
 Finally, we'll add in a boolean constant `_buttonsAreActiveLow` that simply lets us handle pull-up *vs.* pull-down logic in software. The boolean defaults to `true` because we assume a pull-up resistor configuration. Switch this to `false` if you decide to design your button circuits with pull-down resistors.
 
-{% highlight cpp %}
+```cpp
 // I lay out my buttons like piano keys. So, lower frequencies on left
 // and increasingly higher frequencies to the right
 // Change this depending on how you've laid out your keys
@@ -123,13 +123,13 @@ const int OUTPUT_LED_PIN = LED_BUILTIN; // visual feedback on button press
 // Switch the following to false and change INPUT_PULLUP belows
 // to INPUT
 const boolean _buttonsAreActiveLow = true; 
-{% endhighlight cpp %}
+```
 
 #### Step 3: Setup our I/O pins in setup()
 
 In setup(), we simply initialize our **five inputs** and **two outputs** as inputs and outputs accordingly. Note the `INPUT_PULLUP` flag for each button input.
 
-{% highlight cpp %}
+```cpp
 void setup() {
   pinMode(INPUT_BUTTON_C_PIN, INPUT_PULLUP);
   pinMode(INPUT_BUTTON_D_PIN, INPUT_PULLUP);
@@ -139,7 +139,7 @@ void setup() {
   pinMode(OUTPUT_PIEZO_PIN, OUTPUT);
   pinMode(OUTPUT_LED_PIN, OUTPUT);
 }
-{% endhighlight cpp %}
+```
 
 #### Step 4: Write core piano logic in loop()
 
@@ -147,7 +147,7 @@ Because tone() can only play one frequency at a time (darn, no rockin' chords), 
 
 To more easily handle both pull-up and pull-down circuit configurations, we wrote a convenience function called `isButtonPressed(int btnPin)`, which abstracts the "isPressed" logic. (Though one might criticize the use of a global variable—tis common for these rapid prototypes, I'm afraid. You could pass the global var as a parameter into `isButtonPressed` if this makes you feel better about code modularity). 
 
-{% highlight cpp %}
+```cpp
 void loop() {
 
   // tone() generates a square wave of the specified frequency (and 50% duty cycle) on a pin. 
@@ -189,7 +189,7 @@ boolean isButtonPressed(int btnPin){
   // button is not pressed
   return false;
 }
-{% endhighlight cpp %}
+```
 
 #### Step 5: Compile, upload, and run the code
 

--- a/arduino/potentiometers-old.md
+++ b/arduino/potentiometers-old.md
@@ -340,7 +340,7 @@ Just like with our [button](buttons.md) lesson, let's walk through how one might
 
 Let's first introduce a simple program to read and print analog input values to Serial. This will provide a convenient way to test our input circuits.
 
-{% highlight C %}
+```cpp
 void setup()
 {
   Serial.begin(9600); // for printing values to console
@@ -352,7 +352,7 @@ void loop()
   Serial.println(potVal);      // print value to Serial
   delay(50);                   // Reading new values at ~20Hz
 }
-{% endhighlight C %}
+```
 
 ### Building an initial circuit
 

--- a/arduino/potentiometers.md
+++ b/arduino/potentiometers.md
@@ -250,9 +250,9 @@ In fact, if you flip over the Leonardo, you'll discover additional white silkscr
 
 You can access these by specifying `A6` - `A11` in your code. For example:
 
-{% highlight cpp %}
+```cpp
 int analogVal = analogRead(A6); // A6 is same as D4
-{% endhighlight cpp %}
+```
 
 Another view of the back of the Arduino Leonardo board showing the additional analog input pins. 
 
@@ -360,7 +360,7 @@ Just like with our [button](buttons.md) lesson, let's walk through how one might
 
 Let's first introduce a simple program to read and print analog input values to Serial. This will provide a convenient way to test our input circuits.
 
-{% highlight cpp %}
+```cpp
 void setup()
 {
   Serial.begin(9600); // for printing values to console
@@ -372,7 +372,7 @@ void loop()
   Serial.println(potVal);      // print value to Serial
   delay(50);                   // Reading new values at ~20Hz
 }
-{% endhighlight cpp %}
+```
 
 ### Building an initial circuit
 

--- a/arduino/rgb-led-fade.md
+++ b/arduino/rgb-led-fade.md
@@ -66,20 +66,20 @@ Our particular crossfade method works by **increasing** one LED color value (fro
 
 More specifically, we have an array `int _rgbLedValues[3]` that stores our `{int red, int green, int blue}` values. We initialize the array to `{255, 0, 0}`—so `red=255`, `green=0`, and `blue=0`. So, our RGB LED will start red. 
 
-{% highlight C %}
+```cpp
 int _rgbLedValues[] = {255, 0, 0}; // Red, Green, Blue
-{% endhighlight C %}
+```
 
 To help index into this array and track state, we create the following `enum`:
 
-{% highlight C %}
+```cpp
 enum RGB{
   RED,
   GREEN,
   BLUE,
   NUM_COLORS
 };
-{% endhighlight C %}
+```
 
 This enum allows us to access our RGB LED values by writing `_rgbLedValues[RED]`, `_rgbLedValues[GREEN]`, and `_rgbLedValues[BLUE]` rather than `_rgbLedValues[0]`, `_rgbLedValues[1]`, and `_rgbLedValues[2]`. The enum doesn't just improve code readability and help avoid needless array index errors, it's also used to track state with two state-tracking variables: `_curFadingUpColor` and `_curFadingDownColor`.  
 
@@ -89,7 +89,7 @@ Once we reach our maximum color value of `255` for the current `_curFadingUpColo
 
 The full fade algorithm is captured in `loop()`:
 
-{% highlight C %}
+```cpp
 // Code based on https://gist.github.com/jamesotron/766994 (no longer available)
 void loop() {
 
@@ -126,7 +126,7 @@ void loop() {
   setColor(_rgbLedValues[RED], _rgbLedValues[GREEN], _rgbLedValues[BLUE]);
   delay(DELAY_MS);
 }
-{% endhighlight C %}
+```
 
 We control the fade step—the *amount* to fade on each `loop()` iteration—with `const int FADE_STEP`. With `FADE_STEP=1`, we fade between 768 color combinations (`3*256`). By default, `FADE_STEP=5`, which results in 156 color combinations.
 
@@ -176,7 +176,7 @@ A screen recording of [Hunor Marton's HSL Color Picker](https://codepen.io/Hunor
 
 In our case, we perform this HSL-to-RGB conversion using the [RGBConverter](https://github.com/ratkins/RGBConverter) library. With this HSL approach, our code is comparatively much simpler, something like the following pseudocode:
 
-{% highlight C %}
+```cpp
 // Basic overview of our approach (pseudocode)
 float hue = 0, saturation = 0.8, lightness = 1.0;
 float hueStepValue = 0.1f; // increment hue but keep saturation and lightness fixed
@@ -189,7 +189,7 @@ loop(){
         hue = 0;
     }
 }
-{% endhighlight C %}
+```
 
 The downside of this implementation is that we must use [`floats`](https://www.arduino.cc/en/pmwiki.php?n=Reference/Float) because the [RGBConverter](https://github.com/ratkins/RGBConverter) library uses floating point functions. Why are floats bad? Two reasons: with the ATmega328 microcontroller, floating point arithmetic is **slow** (`float` division can be 2-4 times slower than `integer` division) and **[imprecise](https://www.arduino.cc/en/pmwiki.php?n=Reference/Float)** (floats can appear infinitely precise given their use of decimals but on the ATmega328, floats have ~6-7 decimal digits of precision).
 
@@ -240,7 +240,7 @@ Well, it turns out this fundamental feature has a long, sordid history in the Ar
 
 **First** and easiest, place all `.h` and `.cpp` files in your root sketch folder (where your `.ino` file resides):
 
-```
+```text
 CrossFadeHue
 |-CrossFadeHue.ino
 |-RGBConverter.cpp
@@ -249,7 +249,7 @@ CrossFadeHue
 
 **Second**, place all `.h` and `.cpp` files in a sub-folder off or your root sketch folder with a dir name of your choosing (*e.g.,* `lib`):
 
-```
+```text
 CrossFadeHue
 |-CrossFadeHue.ino
 |-lib
@@ -259,7 +259,7 @@ CrossFadeHue
 
 **Third**, if you have lots of `.h` and `.cpp` files and want to organize them into their own individual sub-folders, then... this can be frustrating! But there is a solution since the ~Arduino 1.6 release: you must put these sub-folders into a sub-folder called `src` ([link](https://github.com/arduino/Arduino/issues/4936#issuecomment-312953260)) within your root sketch directory. Indeed, this is exactly our setup for using the [RGBConverter](https://github.com/ratkins/RGBConverter) library. It's in `CrossFadeHue\src\RGBConverter`. So, your directory structure should look like:
 
-```
+```text
 CrossFadeHue
 |-CrossFadeHue.ino
 |-src

--- a/arduino/rgb-led.md
+++ b/arduino/rgb-led.md
@@ -82,18 +82,18 @@ And here's the wiring with a breadboard (the schematic on the right is the same 
 We are going to write code that flashes through a sequence of colors. Recall that the embedded red LED is hooked up to Pin 6, the blue LED to Pin 5, and the green LED to Pin 3. We will control the RGB LED color by outputting `HIGH` (5V) or `LOW` (0V) using [`digitalWrite` ](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalwrite/) to these pins.
 
 For example, to make the RGB LED turn red, we would write:
-{% highlight C %}
+```cpp
 digitalWrite(RGB_RED_LED_PIN, HIGH);
 digitalWrite(RGB_GREEN_LED_PIN, LOW);
 digitalWrite(RGB_BLUE_LED_PIN, LOW);
-{% endhighlight C %}
+```
 
 Similarly, to make the RGB LED turn green, we would write:
-{% highlight C %}
+```cpp
 digitalWrite(RGB_RED_LED_PIN, LOW);
 digitalWrite(RGB_GREEN_LED_PIN, HIGH);
 digitalWrite(RGB_BLUE_LED_PIN, LOW);
-{% endhighlight C %}
+```
 
 In this example, we will flash the following sequence:
 
@@ -117,7 +117,7 @@ blue by <span style="background-color:#0000FF; color:white">#0000FF</span>, and 
 
 As usual, we introduce some constants for our literal assignments and then setup our pins as `OUTPUT`.
 
-{% highlight C %}
+```cpp
 const int DELAY_MS = 1000;       // delay between color changes in ms
 const int RGB_RED_LED_PIN = 6;   // indicated by orange wire
 const int RGB_GREEN_LED_PIN = 5; // indicated by green wire
@@ -130,26 +130,26 @@ void setup()
   pinMode(RGB_BLUE_LED_PIN, OUTPUT);
   pinMode(RGB_GREEN_LED_PIN, OUTPUT);
 }
-{% endhighlight C %}
+```
 
 #### Step 2: Write a new helper function called setRgbLedColor
 
 To help set RGB LED colors, we are going to write a new function called `setRgbLedColor(int red, int green, int blue)`, which takes in either a `HIGH` or `LOW` for the red, green, and blue int parameters.
 
-{% highlight C %}
+```cpp
 // Function expects either HIGH or LOW for each parameter
 void setRgbLedColor(int red, int green, int blue){
   digitalWrite(RGB_RED_LED_PIN, red);
   digitalWrite(RGB_GREEN_LED_PIN, green);
   digitalWrite(RGB_BLUE_LED_PIN, blue);
 }
-{% endhighlight C %}
+```
 
 #### Step 3: Write the color sequence
 
 Now, in `loop()`, we'll write the specific color sequence that we want:
 
-{% highlight C %}
+```cpp
 void loop()
 {
   // red
@@ -176,7 +176,7 @@ void loop()
   setRgbLedColor(HIGH, HIGH, HIGH);
   delay(DELAY_MS);
 }
-{% endhighlight C %}
+```
 
 #### Step 4: Compile, upload, and run
 
@@ -223,18 +223,18 @@ And here's the more practical breadboarded version (again, the circuit diagram i
 
 The Common Anode RGB LED works **opposite** to the Common Cathode version—to turn on a particular color, we write out `LOW` rather than `HIGH`. For example, to make the RGB LED turn red, we would write:
 
-{% highlight C %}
+```cpp
 digitalWrite(RGB_RED_LED_PIN, LOW);
 digitalWrite(RGB_GREEN_LED_PIN, HIGH);
 digitalWrite(RGB_BLUE_LED_PIN, HIGH);
-{% endhighlight C %}
+```
   
 Similarly, to make the RGB LED turn green, we would write:
-{% highlight C %}
+```cpp
 digitalWrite(RGB_RED_LED_PIN, HIGH);
 digitalWrite(RGB_GREEN_LED_PIN, LOW);
 digitalWrite(RGB_BLUE_LED_PIN, HIGH);
-{% endhighlight C %}
+```
 
 We will flash the same sequence as before but again our `HIGH`s and `LOW`s are flipped:
 

--- a/arduino/serial-print.md
+++ b/arduino/serial-print.md
@@ -66,19 +66,19 @@ To use the serial port, we must first initialize it with [`Serial.begin(BAUD_RAT
 
 Typically, we initialize the serial port in `setup()`, as it only needs to run one time.
 
-{% highlight C %}
+```cpp
 void setup() {
   Serial.begin(9600); // opens serial port, sets data rate to 9600 bps
 }
 
 void loop() {}
-{% endhighlight C %}
+```
 
 #### Step 2: Use Serial.print and Serial.println to write data
 
 Here's a complete program that writes "Hello world!" once every 500 ms.
 
-{% highlight C %}
+```cpp
 void setup() {
   Serial.begin(9600); // opens serial port, sets data rate to 9600 bps
 }
@@ -87,7 +87,7 @@ void loop() {
   Serial.println("Hello world!");
   delay(500);
 }
-{% endhighlight C %}
+```
 
 #### Step 3: Open 'Serial Monitor' in the Arduino IDE
 
@@ -109,7 +109,7 @@ The simple answer is to use multiple `Serial.print` and `Serial.println` stateme
 
 Below, we've written a simple program to print out the current time (in milliseconds) since the Arduino was turned on and our program began to run:
 
-{% highlight C %}
+```cpp
 void setup() {
   Serial.begin(9600); // opens serial port, sets data rate to 9600 bps
 }
@@ -123,7 +123,7 @@ void loop() {
   Serial.println(" ms");
   delay(500);
 }
-{% endhighlight C %}
+```
 
 ![Serial Monitor showing timestamp output from the Arduino](assets/images/SerialPrintTimeStamp_ArduinoSerialMonitorScreenshot.png)
 
@@ -135,7 +135,7 @@ This code is also on GitHub [here](https://github.com/makeabilitylab/arduino/blo
 
 Now, let's return to our [blink code](led-blink.md) and modify it to use `Serial.print` to print out when the LED is on and off. 
 
-{% highlight C++ %}
+```cpp
 const int LED_OUTPUT_PIN = 3;
 
 void setup() {
@@ -155,7 +155,7 @@ void loop() {
   Serial.println("Pin 3 is LOW (0V)");  // print status
   delay(500);                           // delay is in milliseconds
 }
-{% endhighlight C++ %}
+```
 
 Here's a video of my code running with the Serial Monitor in the background.
 
@@ -175,7 +175,7 @@ On the Arduino Uno and Leonardo, the built-in LED is on Pin 13. So, if you write
 
 In fact, the official [Arduino Blink example](https://www.arduino.cc/en/Tutorial/Blink) uses the built-in LED and the constant `LED_BUILTIN` to demonstrate blinking. This is also the program that ships with your Arduino and runs when you first power it up.
 
-{% highlight C %}
+```cpp
 // the setup function runs once when you press reset or power the board
 void setup() {
   // initialize digital pin LED_BUILTIN as an output.
@@ -189,7 +189,7 @@ void loop() {
   digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
   delay(1000);                       // wait for a second
 }
-{% endhighlight C %}
+```
 
 You can access this example directly in the Arduino IDE:
 
@@ -205,7 +205,7 @@ A third approach, which also uses serial, is called [**Serial Plotter**](https:/
 
 Let's make a new program that steadily increases a state value called `_triangleValue`. Once it passes a certain threshold `TURN_ON_THRESHOLD`, we turn on the LED at `LED_BUILTIN`.
 
-{% highlight C %}
+```cpp
 const int LED_OUTPUT_PIN = LED_BUILTIN;
 const int MAX_THRESHOLD = 255;
 const int MIN_THRESHOLD = 0;
@@ -236,7 +236,7 @@ void loop() {
 
   delay(30);
 }
-{% endhighlight C %}
+```
 
 To open the Serial Plotter, go to `Tools -> Serial Plotter` or click on the "graph icon" in the Arduino IDE toolbar. Here's a video of this code running with the Serial Plotter showing a triangle wave.
 
@@ -250,13 +250,13 @@ To open the Serial Plotter, go to `Tools -> Serial Plotter` or click on the "gra
 
 The Arduino IDE 2 Serial Plotter supports **multiple named data lines** with auto-generated legends and distinct colors. To use this feature, format your output as comma-separated `Label:value` pairs, ending with a newline. For example:
 
-```
+```text
 Label1:value1,Label2:value2\n
 ```
 
 Let's modify our previous program but graph the `TURN_ON_THRESHOLD`.
 
-{% highlight C %}
+```cpp
 const int LED_OUTPUT_PIN = LED_BUILTIN;
 const int MAX_THRESHOLD = 255;
 const int MIN_THRESHOLD = 0;
@@ -291,7 +291,7 @@ void loop() {
 
   delay(30);
 }
-{% endhighlight C %}
+```
 
 In the Serial Plotter, you'll see two colored lines with a legend: `Turn-on Threshold` as a solid line at the `TURN_ON_THRESHOLD` value and `Triangle` as a triangular ramp of `_triangleValue`. The IDE automatically assigns colors and generates the legend from your labels. You can click on the checkboxes to toggle which values are graphed.
 
@@ -308,7 +308,7 @@ In the Serial Plotter, you'll see two colored lines with a legend: `Turn-on Thre
 
 Once you learn [`analogRead`](https://www.arduino.cc/reference/en/language/functions/analog-io/analogread/) in a [future lesson](potentiometers.md), the Serial Plotter becomes especially powerful for visualizing real sensor data. For example, you could plot a sensor reading alongside a threshold value and use the built-in LED to indicate when the threshold is crossed:
 
-{% highlight C %}
+```cpp
 const int SENSOR_PIN = A0;
 const int THRESHOLD = 800;
 
@@ -336,7 +336,7 @@ void loop() {
 
   delay(50);
 }
-{% endhighlight C %}
+```
 
 The Serial Plotter shows the sensor value fluctuating in real time with a flat threshold line for comparison, and the built-in LED lights up whenever the value goes above the threshold—giving you both visual feedback on the board *and* a graph on screen. This combination of Serial Plotter + indicator LED is a technique you'll use frequently when calibrating sensors and tuning interactive projects.
 

--- a/arduino/tone.md
+++ b/arduino/tone.md
@@ -99,7 +99,7 @@ As you turn the potentiometer, listen carefully: in the `analogWrite()` mode, th
 **Figure.** A Tinkercad Circuits simulation demonstrating that `analogWrite` changes the duty cycle (visible on the oscilloscope) but not the frequency—so the buzzer pitch remains constant.
 {: .fs-1 } -->
 
-<!-- {% highlight cpp %}
+<!-- ```cpp
 // Uses a PWM sweep to demonstrate that analogWrite has a fixed frequency
 // but different duty cycle; so the speaker pitch is always the same!
 // This is why we need tone(), which has a fixed 50% duty cycle
@@ -134,7 +134,7 @@ void loop() {
 
   delay(DELAY_BETWEEN_STEPS);
 }
-{% endhighlight cpp %}
+```
 
 Compare this with `tone()`, where the duty cycle is always 50% but you control the frequency (pitch) directly. This is the fundamental distinction! -->
 
@@ -142,11 +142,11 @@ Compare this with `tone()`, where the duty cycle is always 50% but you control t
 
 Arduino provides three functions for generating tones:
 
-{% highlight cpp %}
+```cpp
 tone(pin, frequency)              // play continuously until noTone() is called
 tone(pin, frequency, duration)    // play for 'duration' milliseconds, then stop
 noTone(pin)                       // stop playing
-{% endhighlight cpp %}
+```
 
 A few important details:
 
@@ -239,7 +239,7 @@ To let you interactively explore the difference, we built this p5js sound visual
 
 Let's start by playing a single tone. The following code plays concert A (440 Hz) for one second, pauses for half a second, then repeats. You can [play with it interactively on Tinkercad](https://www.tinkercad.com/things/aqUoDUiMU7x-simple-tone) or copy/paste it into the Arduino IDE and run it for real!
 
-{% highlight cpp %}
+```cpp
 const int BUZZER_PIN = 9;
 
 void setup() {
@@ -252,7 +252,7 @@ void loop() {
   noTone(BUZZER_PIN);        // Stop tone
   delay(500);                // Pause for half a second
 }
-{% endhighlight cpp %}
+```
 
 Try changing the frequency: 262 is middle C, 523 is one octave higher (C5), and 1000 produces a high-pitched tone. What's the lowest frequency you can hear? The highest? (Most humans can hear roughly 20 Hz to 20 kHz, but this varies with age.) Note: The standard Arduino `tone()` function has a minimum frequency of 31 Hz due to hardware timer limitations, so you won't be able to test the absolute bottom of human hearing (20 Hz).
 
@@ -269,7 +269,7 @@ Now let's play something more musical. The Arduino IDE ships with a helpful file
 
 Here are a few of the note definitions from [`pitches.h`](https://github.com/arduino/arduino-examples/blob/main/examples/02.Digital/toneMelody/pitches.h). You can also find musical note frequencies in this [Piano Key Frequencies article](https://en.wikipedia.org/wiki/Piano_key_frequencies) on Wikipedia.
 
-{% highlight cpp %}
+```cpp
 #define NOTE_C4  262   // Middle C
 #define NOTE_D4  294
 #define NOTE_E4  330
@@ -278,11 +278,11 @@ Here are a few of the note definitions from [`pitches.h`](https://github.com/ard
 #define NOTE_A4  440   // Concert A
 #define NOTE_B4  494
 #define NOTE_C5  523   // C one octave above middle C
-{% endhighlight cpp %}
+```
 
 Using these constants, we can play a C major scale:
 
-{% highlight cpp %}
+```cpp
 #define NOTE_C4  262   // Middle C
 #define NOTE_D4  294
 #define NOTE_E4  330
@@ -323,7 +323,7 @@ void loop() {
   
   delay(1000); // pause before repeating
 }
-{% endhighlight cpp %}
+```
 
 Notice that we use the `duration` parameter of `tone()` here, so we don't need to call `noTone()` manually—the tone stops automatically after `NOTE_DURATION_MS` milliseconds. One subtlety: `tone()` is **non-blocking**, meaning the sketch continues executing immediately even while the tone is still playing. That's why we still need the `delay()` call—without it, the loop would race ahead to the next note before the current one finishes.
 
@@ -346,7 +346,7 @@ The Arduino IDE includes a built-in example that plays a short melody. You can a
 
 Instead, we've written our own version using the Imperial March from Star Wars. You can [try it on Tinkercad here](https://www.tinkercad.com/things/l2d7xFFuWFY/).
 
-{% highlight cpp %}
+```cpp
 #define NOTE_C4  262
 #define NOTE_D4  294
 #define NOTE_E4  330
@@ -419,7 +419,7 @@ void setup() {
 void loop() {
   // Melody plays once in setup(), nothing to do here
 }
-{% endhighlight cpp %}
+```
 
 To represent a rest (silence), use a note value of `0` in the melody array. The code checks for this and simply skips the `tone()` call, relying on the `delay()` to produce a silent pause. Avoid calling `tone(pin, 0)` directly—while it happens to produce silence on AVR boards, it causes crashes on other platforms (like SAMD) due to a division by zero in the timer math.
 
@@ -448,7 +448,7 @@ The simplest approach is to turn an LED on while a note plays and off during the
 **Figure.** A Tinkercad Circuits simulation of a simple siren with an LED that toggles with each tone change. Try it yourself in [Tinkercad](https://www.tinkercad.com/things/frb7eeyVkKN-simple-siren-with-external-led-no-breadboard/)!
 {: .fs-1 }
 
-{% highlight cpp %}
+```cpp
 const int BUZZER_PIN = 9;
 const int LED_PIN = 2;
 const int SOUND_DURATION_MS = 500;
@@ -469,7 +469,7 @@ void loop() {
   digitalWrite(LED_PIN, LOW);      // LED off for low tone
   delay(SOUND_DURATION_MS);
 }
-{% endhighlight cpp %}
+```
 
 <video controls playsinline aria-label="A simple siren video playing alternating tones with an LED flashing on and off">
   <source src="assets/videos/Arduino_Tone-SimpleSirenWithLED_Handheld_web.mp4" type="video/mp4" />
@@ -487,7 +487,7 @@ You can also check out our Imperial March code, which also turns on the `BUILTIN
 
 For a more sophisticated effect, we can use `analogWrite` to map the note frequency to LED brightness—higher notes produce a brighter LED:
 
-{% highlight cpp %}
+```cpp
 #include "pitches.h"
 
 const int BUZZER_PIN = 9;
@@ -517,7 +517,7 @@ void loop() {
 
   delay(1000);
 }
-{% endhighlight cpp %}
+```
 
 As the scale ascends, the LED gets brighter. As it descends, the LED dims. This is a simple example of **data-driven multimodal output**—the same data (the note being played) drives two different output channels (sound and light). -->
 

--- a/communication/handpose-serial.md
+++ b/communication/handpose-serial.md
@@ -92,7 +92,7 @@ The 21 keypoints include four each for the `thumb`, `index_finger`, `middle_fing
 
 In ml5.js v1.x, each keypoint is an object with `x`, `y`, `z` coordinates and a `name` property. The keypoint names are:
 
-{% highlight JavaScript %}
+```javascript
 // The 21 HandPose keypoint names in ml5 v1.x
 // Index 0: "wrist"
 // Thumb:  "thumb_cmc", "thumb_mcp", "thumb_ip", "thumb_tip"
@@ -100,7 +100,7 @@ In ml5.js v1.x, each keypoint is an object with `x`, `y`, `z` coordinates and a 
 // Middle: "middle_finger_mcp", "middle_finger_pip", "middle_finger_dip", "middle_finger_tip"
 // Ring:   "ring_finger_mcp", "ring_finger_pip", "ring_finger_dip", "ring_finger_tip"
 // Pinky:  "pinky_finger_mcp", "pinky_finger_pip", "pinky_finger_dip", "pinky_finger_tip"
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **v0.x vs v1.x keypoint naming:** The old ml5 v0.x API used `landmarks` (raw `[x,y,z]` arrays) and `annotations` (grouped by finger name like `thumb`, `indexFinger`). The new v1.x API uses `keypoints` (objects with `{x, y, z, name}`) and provides named shortcuts like `hand.wrist`, `hand.index_finger_tip`, *etc.* The keypoint indices are the same, but accessing them is more intuitive in v1.x.
@@ -132,7 +132,7 @@ In ml5 v1.x, the HandPose model returns an array of detected hand objects. Each 
 
 The array structure looks like this:
 
-{% highlight JavaScript %}
+```javascript
 // hands is an array of detected hands (ml5 v1.x supports multiple)
 [
   {
@@ -152,7 +152,7 @@ The array structure looks like this:
     // ... shortcuts for all 21 keypoints
   }
 ]
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **v0.x vs v1.x data structure:** If you're looking at older tutorials, note that the old HandPose API returned `predictions[0].landmarks[j]` as raw `[x, y, z]` arrays and used `handInViewConfidence`. The new v1.x API returns `hands[0].keypoints[j]` as objects with `{x, y, z, name}` and uses `confidence`. The named shortcuts (*e.g.,* `hand.wrist`) are new in v1.x.
@@ -204,7 +204,7 @@ We'll begin by building the web app in [p5.js](https://p5js.org/) and [ml5](http
 
 First, add the ml5.js library to your `index.html`, just like we did in the [previous lesson](ml5js-serial.md#add-in-ml5js):
 
-{% highlight HTML %}
+```html
 <head>
   <script src="https://cdn.jsdelivr.net/npm/p5@1.11.13/lib/p5.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/makeabilitylab/js@main/dist/makelab.serial.iife.js"></script>
@@ -212,7 +212,7 @@ First, add the ml5.js library to your `index.html`, just like we did in the [pre
   <link rel="stylesheet" type="text/css" href="css/style.css">
   <meta charset="utf-8">
 </head>
-{% endhighlight HTML %}
+```
 
 {: .note }
 > We're pinning to **ml5.js v1.3.1** via the `ml5@1.3.1` in the `<script src>` link to ensure the API doesn't change unexpectedly. Always pin your library versions in course projects!
@@ -221,7 +221,7 @@ First, add the ml5.js library to your `index.html`, just like we did in the [pre
 
 The ml5 library aims to create consistency across its APIs. Thus, the ml5 HandPose API should feel familiar if you followed our previous [BodyPose lesson](ml5js-serial.md). Just like with BodyPose, we initialize the model in `preload()` and start continuous detection with `detectStart()` in `setup()`:
 
-{% highlight JavaScript %}
+```javascript
 let handPose;                   // the ml5 HandPose model
 let video;                      // the webcam video stream
 let hands = [];                 // array of detected hands
@@ -243,7 +243,7 @@ function setup() {
 function onHandsDetected(results) {
   hands = results;
 }
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **`detectStart()` vs the old `.on('predict')` pattern:** In ml5 v0.x, you subscribed to hand pose events with `handPoseModel.on('predict', callback)`. In v1.x, you call `handPose.detectStart(video, callback)`, which internally manages the detection loop. This is simpler, more consistent with other ml5 models, and prevents accidental recursive loop issues.
@@ -259,7 +259,7 @@ Now, the fun part! Let's add drawing code to render three things:
 
 First, let's update the `draw()` function to show the webcam video and draw detected hands:
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   image(video, 0, 0, width, height);
 
@@ -279,7 +279,7 @@ function draw() {
     drawBoundingBox(hand);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 It should look something like this before a hand is detected:
 
@@ -289,7 +289,7 @@ It should look something like this before a hand is detected:
 
 Now, let's add the `drawHand(hand)` function. We will iterate through all 21 keypoints and draw a green circle at their x,y position. In v1.x, each keypoint is an object with `.x` and `.y` properties:
 
-{% highlight JavaScript %}
+```javascript
 function drawHand(hand) {
   // Draw keypoints. Each keypoint has x, y, z and name properties.
   for (let keypoint of hand.keypoints) {
@@ -298,7 +298,7 @@ function drawHand(hand) {
     circle(keypoint.x, keypoint.y, 10);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Your hand should now have green circles drawn on the keypoints like this:
 
@@ -308,7 +308,7 @@ Your hand should now have green circles drawn on the keypoints like this:
 
 Lastly, let's add a `drawBoundingBox(hand)` function. In v1.x, there is no built-in bounding box property, so we calculate one from the keypoints. We'll also display the `confidence` score:
 
-{% highlight JavaScript %}
+```javascript
 function drawBoundingBox(hand) {
   // Calculate bounding box from keypoints
   let minX = Infinity, minY = Infinity;
@@ -333,7 +333,7 @@ function drawBoundingBox(hand) {
   textSize(20);
   text(nfc(hand.confidence, 2), minX, minY);
 }
-{% endhighlight JavaScript %}
+```
 
 Here's a screenshot with the keypoints, bounding box, and confidence:
 
@@ -350,15 +350,15 @@ You can view, edit, and play with [this code](https://editor.p5js.org/jonfroehli
 For the final step, we'll add code to transmit the `wrist` keypoint's normalized x position [0, 1] via web serial. To avoid saturating web serial with data, we will also limit our transmission rate to ~20Hz (one transmission every 50ms). Lastly, let's also add drawing code to show `wrist` information on screen (useful for debugging!).
 
 First, add some global variables:
-{% highlight JavaScript %}
+```javascript
 let wristXNormalized = 0;
 let timestampLastTransmit = 0;
 const MIN_TIME_BETWEEN_TRANSMISSIONS_MS = 50; // 50 ms is ~20 Hz
-{% endhighlight JavaScript %}
+```
 
 Then update the `onHandsDetected` callback to calculate and transmit `wristXNormalized`:
 
-{% highlight JavaScript %}
+```javascript
 function onHandsDetected(results) {
   hands = results;
 
@@ -385,14 +385,14 @@ function onHandsDetected(results) {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **`wrist` vs `palmBase`:** In the old v0.x API, the base of the palm was accessed as `landmarks[0]` or `annotations.palmBase`. In v1.x, the same keypoint is called `wrist` and can be accessed as `hand.wrist` or `hand.keypoints[0]`. The position data is the same—only the naming changed.
 
 Finally, update the `draw()` function to draw wrist info on screen:
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   ...
   if (hands.length > 0) {
@@ -410,7 +410,7 @@ function draw() {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And that's it! Because our [`SerialTemplate`](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/SerialTemplate) already supports connecting to a serial device by clicking on the canvas (by default) and/or auto-connecting to previously approved web serial devices, we are all set. Feel free to add your own connection code (*e.g.,* a specific "Connect Button" for web serial). The full code is [here](https://editor.p5js.org/jonfroehlich/sketches/vMbPOkdzu).
 
@@ -454,7 +454,7 @@ As a quick introduction to servo motors, please read this [Adafruit lesson](http
 
 The code, in full, is:
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h> 
 
 const int POTENTIOMETER_INPUT_PIN = A0;  
@@ -478,7 +478,7 @@ void loop()
   // Set servo angle
   _servo.write(servoAngle);  
 }
-{% endhighlight C++ %}
+```
 
 **Code.** This code is in our GitHub as [ServoPot.ino](https://github.com/makeabilitylab/arduino/blob/master/Basics/servo/ServoPot/ServoPot.ino).
 {: .fs-1 }
@@ -497,7 +497,7 @@ Let's update our code to set the servo motor angle based on **serial input** rat
 
 The full code:
 
-{% highlight C++ %}
+```cpp
 #include <Servo.h> 
 
 const int SERVO_OUTPUT_PIN = 9;
@@ -543,7 +543,7 @@ void loop()
     _servo.write(_serialServoAngle);
   }
 } 
-{% endhighlight C++ %}
+```
 
 **Code.** The full code is here [ServoSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/ServoSerialIn/ServoSerialIn.ino).
 {: .fs-1 }
@@ -579,14 +579,14 @@ The p5.js function [`mouseMoved()`](https://p5js.org/reference/#/p5/mouseMoved) 
 
 First, create two global variables for mouse tracking:
 
-{% highlight JavaScript %}
+```javascript
 let xMouseConstrained = 0;
 let xMouseNormalized = 0;
-{% endhighlight JavaScript %}
+```
 
 Now, implement the `mouseMoved()` function:
 
-{% highlight JavaScript %}
+```javascript
 function mouseMoved(){
   xMouseConstrained = constrain(mouseX, 0, width); // get current x mouse pos
   xMouseNormalized = xMouseConstrained / width; // normalize x position
@@ -595,13 +595,13 @@ function mouseMoved(){
     serial.writeLine(nf(xMouseNormalized, 0, 4)); // write out normalized value, if serial is connected/open
   }
 }
-{% endhighlight JavaScript %}
+```
 
 ##### Add in draw code for x mouse position
 
 Finally, add drawing code to display a gray line for the current x mouse position and large text for the normalized value:
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
   
@@ -618,7 +618,7 @@ function draw() {
   textAlign(CENTER, CENTER);
   text(nf(xMouseNormalized, 0, 4), width / 2, height / 2);
 }
-{% endhighlight JavaScript %}
+```
 
 You can view, edit, and play with the [XMouseSerialOut](https://makeabilitylab.github.io/p5js/WebSerial/p5js/XMouseSerialOut/) app in the [p5.js web editor](https://editor.p5js.org/jonfroehlich/sketches/iwbGN0wkj) or on GitHub ([live page](https://makeabilitylab.github.io/p5js/WebSerial/p5js/XMouseSerialOut/), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/XMouseSerialOut)).
 
@@ -683,10 +683,10 @@ Now testing with [HandWaver](https://makeabilitylab.github.io/p5js/WebSerial/ml5
 
 From these tests, we determined that a good range of motion for Henry's arm is 40 - 85 degrees, so we updated our Arduino sketch:
 
-{% highlight C++ %}
+```cpp
 const int MIN_SERVO_ANGLE = 40;
 const int MAX_SERVO_ANGLE = 85;
-{% endhighlight C++ %}
+```
 
 <!-- TODO: then we made a stand -->
 

--- a/communication/ml5js-serial.md
+++ b/communication/ml5js-serial.md
@@ -167,7 +167,7 @@ ml5's BodyPose returns an array of detected poses—one per human detected in a 
 
 The data structure looks like this:
 
-{% highlight JavaScript %}
+```javascript
 // poses is an array of detected people
 [
   {
@@ -186,7 +186,7 @@ The data structure looks like this:
   },
   // Additional detected people...
 ]
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **v0.x vs v1.x data structure:** If you're looking at older tutorials, note that the old PoseNet API returned `poses[0].pose.nose.x` (nested under a `pose` property). The new BodyPose API is flatter: `poses[0].nose.x`. The keypoint names also changed slightly (*e.g.,* `leftEye` → `left_eye`).
@@ -228,7 +228,7 @@ Start by copying our [SerialTemplate](https://github.com/makeabilitylab/p5js/tre
 
 To use ml5.js, we need to add the library to our `index.html`. Add the following `<script>` tag in the `<head>`, alongside the p5.js and serial.js libraries we already have:
 
-{% highlight HTML %}
+```html
 <head>
   <script src="https://cdn.jsdelivr.net/npm/p5@1.11.13/lib/p5.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/makeabilitylab/js@main/dist/makelab.serial.iife.js"></script>
@@ -236,7 +236,7 @@ To use ml5.js, we need to add the library to our `index.html`. Add the following
   <link rel="stylesheet" type="text/css" href="css/style.css">
   <meta charset="utf-8">
 </head>
-{% endhighlight HTML %}
+```
 
 {: .note }
 > We're pinning to **ml5.js v1.3.1** to ensure the API doesn't change unexpectedly. This is especially important for ml5.js, which underwent a major breaking change from v0.x to v1.x. Always pin your library versions in course projects!
@@ -245,7 +245,7 @@ To use ml5.js, we need to add the library to our `index.html`. Add the following
 
 Next, let's set up the webcam and ml5's BodyPose model. In the v1.x API, we initialize BodyPose in `preload()` (so the model is ready before `setup()` runs), then start continuous detection with `detectStart()` in `setup()`:
 
-{% highlight JavaScript %}
+```javascript
 let video;
 let bodyPose;
 let poses = [];
@@ -267,7 +267,7 @@ function setup() {
 function onPosesDetected(results) {
   poses = results;
 }
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > **`detectStart()` vs the old `.on('pose')` pattern:** In ml5 v0.x, you subscribed to pose events with `poseNet.on('pose', callback)`. In v1.x, you call `bodyPose.detectStart(video, callback)`, which internally manages the detection loop. This is simpler and prevents accidental recursive loop issues.
@@ -276,7 +276,7 @@ function onPosesDetected(results) {
 
 Now, let's have some fun! Let's draw a red "nose" at the `nose` keypoint.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
   image(video, 0, 0); // draw the video to the canvas
@@ -290,7 +290,7 @@ function draw() {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Here's a video demo:
 
@@ -304,7 +304,7 @@ Here's a video demo:
 
 To make this a bit more fun, we can [muppetify](https://en.wikipedia.org/wiki/The_Muppets) ourselves by adding in some eyes. This is like making a basic Snapchat or Instagram face filter! We'll also modularize our code by creating `drawNose` and `drawEye` functions.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   image(video, 0, 0); // draw the video to the canvas
   for (let human of poses) {
@@ -337,7 +337,7 @@ function drawEye(x, y) {
   fill(0); // black pupils
   circle(x, y, pupilWidth);
 }
-{% endhighlight JavaScript %}
+```
 
 And another video demo to show what we've created thus far! Notice how the pose model will recognize *pictures* of humans as well as real, physical humans in the webcam stream (but not pictures of seals!).
 
@@ -351,7 +351,7 @@ And another video demo to show what we've created thus far! Notice how the pose 
 
 Finally, let's add code to transmit the nose's location over Web Serial. Just as we've done in previous lessons, rather than transmit the raw x,y pixel location, we will transmit a normalized version between [0, 1] inclusive for both x and y. We do this in the `onPosesDetected` callback:
 
-{% highlight JavaScript %}
+```javascript
 function onPosesDetected(results) {
   poses = results;
 
@@ -369,7 +369,7 @@ function onPosesDetected(results) {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 #### Connect to web serial device
 
@@ -377,7 +377,7 @@ Our template code, [`SerialTemplate`](https://github.com/makeabilitylab/p5js/tre
 
 First, if you've never connected to a particular web serial device before, you can click on the canvas where you'll be greeted by a connection dialog:
 
-{% highlight JavaScript %}
+```javascript
 function mouseClicked() {
   if (!serial.isOpen()) {
     try {
@@ -387,13 +387,13 @@ function mouseClicked() {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Second, if you've previously approved the web serial device, it will auto-connect as soon as you run the app. This is done in `setup()`:
 
-{% highlight JavaScript %}
+```javascript
 serial.autoConnectAndOpenPreviouslyApprovedPort(serialOptions);
-{% endhighlight JavaScript %}
+```
 
 #### We're done with the JavaScript app
 
@@ -432,9 +432,9 @@ The NoseTracker Arduino code is similar to [previous lessons](p5js-serial-io.md#
 
 For the face, rather than drawing one using shape primitives (*e.g.,* [`drawCircle`](../advancedio/oled.md#drawing-shapes) calls), we're going to use the built-in face icon from the default font set (which is char index `2`):
 
-{% highlight C++ %}
+```cpp
 _display.drawChar(x, y, (unsigned char)2, SSD1306_WHITE, SSD1306_BLACK, CHAR_SIZE);
-{% endhighlight C++ %}
+```
 
 ![Close-up photo of the OLED display showing the smiley face character from the default font set](assets/images/FaceCharacter2_DefaultFontSet_OLED.png)
 **Figure.** A close-up image of the face icon we'll use from the default character set.
@@ -443,7 +443,7 @@ _display.drawChar(x, y, (unsigned char)2, SSD1306_WHITE, SSD1306_BLACK, CHAR_SIZ
 ##### Parsing the incoming serial data
 First, declare some global variables related to face drawing.
 
-{% highlight C++ %}
+```cpp
 const int CHAR_SIZE = 3;           // set font size to 3
 const int DEFAULT_CHAR_WIDTH = 5;  // default font is 5 pixels wide at size 1
 const int DEFAULT_CHAR_HEIGHT = 8; // default font is 8 pixels tall at size 1
@@ -453,11 +453,11 @@ int _charHeight = DEFAULT_CHAR_HEIGHT * CHAR_SIZE;  // calculate char height at 
 
 float _faceX = 0; // normalized x position of face
 float _faceY = 0; // normalized y position of face
-{% endhighlight C++ %}
+```
 
 Now, in `loop()` look for incoming serial data. If serial data exists, read and parse it into x,y floats.
 
-{% highlight C++ %}
+```cpp
 void loop() {
   // Check to see if there is any incoming serial data
   if(Serial.available() > 0){
@@ -486,20 +486,20 @@ void loop() {
   _display.display();
   delay(DELAY_MS);
 }
-{% endhighlight C++ %}
+```
 
 ##### Drawing the face
 
 We could really draw anything we want at the received x,y position—an animated sprite, a shape, *etc.* In this example, we'll simply draw a face.
 
-{% highlight C++ %}
+```cpp
 void drawFace(float xFrac, float yFrac){
   int x = xFrac * (_display.width() - _charWidth);
   int y = yFrac * (_display.height() - _charHeight);
 
   _display.drawChar(x, y, (unsigned char)2, SSD1306_WHITE, SSD1306_BLACK, CHAR_SIZE);
 }
-{% endhighlight C++ %}
+```
 
 And that's it, the full code is available on GitHub as [NoseTrackerSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/NoseTrackerSerialIn/NoseTrackerSerialIn.ino).
 

--- a/communication/p5js-paint-io.md
+++ b/communication/p5js-paint-io.md
@@ -92,19 +92,19 @@ Begin by copying [`SerialTemplate`](https://github.com/makeabilitylab/p5js/tree/
 
 In `sketch.js`, scroll down and remove the following. We will use a different approach to connect to serial.
 
-{% highlight JavaScript %}
+```javascript
 function mouseClicked() {
   if (!serial.isOpen()) {
     serial.connectAndOpen(null, serialOptions);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Also comment out this line of code in `setup()`, which attempts to automatically connect with previously approved serial devices:
 
-{% highlight JavaScript %}
+```javascript
 // serial.autoConnectAndOpenPreviouslyApprovedPort(serialOptions);
-{% endhighlight JavaScript %}
+```
 
 We want to ignore anything serial related for now.
 
@@ -114,7 +114,7 @@ For the painting code, we will use similar variables and drawing code from [Disp
 
 Add in the following global variables, which include the current `brushType`, `brushSize`, `brushFillMode`, `brushColor`, and brush location (`brushX`, `brushY`). Additionally, rather than paint directly to the canvas, we'll use an off-screen graphics buffer called `offscreenGfxBuffer`—so declare that too. We'll talk more about that next.  
 
-{% highlight JavaScript %}
+```javascript
 const mapBrushTypeToShapeName = {
   0: "Circle",
   1: "Square",
@@ -143,11 +143,11 @@ let showInstructions = true; // If true, shows the app instructions on the scree
 // We will paint to an offscreen graphics buffer
 // See: https://p5js.org/reference/#/p5/createGraphics
 let offscreenGfxBuffer;
-{% endhighlight JavaScript %}
+```
 
 Because we cannot use any p5.js constructs or functions until `setup()` is called, we need to initialize `brushColor` and `offscreenGfxBuffer` in `setup()`. If we try to initialize them at declaration, the p5.js online editor is smart enough to catch this and hint at the problem:
 
-```
+```text
 🌸 p5.js says: There's an error due to "color" not being defined in the current scope (on line 116 in about:srcdoc [about:srcdoc:116:18]).
 
 If you have defined it in your code, you should check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:
@@ -164,7 +164,7 @@ For more details, see: https://github.com/processing/p5.js/wiki/p5.js-overview#w
 
 So, instead, initialize them in `setup()`:
 
-{% highlight JavaScript %}
+```javascript
 function setup() {
   ...
   // Initialize the brush color to a ~white with a ~20% opacity (50/255 is 19.6%)
@@ -177,14 +177,14 @@ function setup() {
   offscreenGfxBuffer = createGraphics(width, height);
   offscreenGfxBuffer.background(100); 
 }
-{% endhighlight JavaScript %}
+```
 
 The [`createGraphics()`](https://p5js.org/reference/#/p5/createGraphics) function lets us create a new offscreen graphics buffer. The function returns a new [p5.Renderer](https://p5js.org/reference/#/p5.Renderer) object, which has the same drawing API as core p5.js. So, if we want to set the background of the offscreen buffer, we would write `offscreenGfxBuffer.background(100);`. If we want to draw a red circle at pixel coordinate `10, 10` with a diameter of 50 on the offscreen buffer, we would write: 
 
-{% highlight JavaScript %}
+```javascript
 offscreenGfxBuffer.fill(255, 0, 0);    // set fill color in offscreen graphics context to red
 offscreenGfxBuffer.circle(10, 10, 50); // draw the circle to the offscreen buffer.
-{% endhighlight JavaScript %}
+```
 
 And so on. We can make the offscreen buffer any size but, in this case, we want it the same size as our canvas, so we pass the canvas  `width` and `height` in the `createGraphics()` call.
 
@@ -192,7 +192,7 @@ And so on. We can make the offscreen buffer any size but, in this case, we want 
 
 In the `draw()` method, we will draw brush strokes to the offscreen buffer and then draw this buffer to canvas.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   // Draw the current brush stroke at the given x, y position
   // But we don't draw to canvas, we draw to the offscreenGfxBuffer
@@ -201,11 +201,11 @@ function draw() {
   // Draw the offscreen buffer to the screen
   image(offscreenGfxBuffer, 0, 0);
 }
-{% endhighlight JavaScript %}
+```
 
 Obviously, we also need to add the `drawBrushStroke()` method, which should feel familiar and understandable from [previous lessons](p5js-serial-io.md). The only difference is that we are drawing to the offscreen buffer object `offscreenGfxBuffer`. 
 
-{% highlight JavaScript %}
+```javascript
 function drawBrushStroke(xBrush, yBrush){
   // set the fill and outline brush settings
   if (brushFillMode == 0) { // brushFillMode 0 is fill
@@ -242,7 +242,7 @@ function drawBrushStroke(xBrush, yBrush){
       offscreenGfxBuffer.triangle(x1, y1, x2, y2, x3, y3)
   }
 }
-{% endhighlight JavaScript %}
+```
 
 ### Why use an offscreen buffer?
 
@@ -268,7 +268,7 @@ It's simply an easy approach for us to "store" all of the painting operations th
 
 Because we're using this offscreen graphics buffer, it's easy to draw a "layer" on top of the user's painting with other graphics—in this case, user instructions. Crucially, unlike the paint strokes, we are **not** drawing these instructions to the offscreen buffer but rather directly onto the canvas.
 
-{% highlight JavaScript %}
+```javascript
 function drawInstructions(){
   // Some instructions to the user
   noStroke();
@@ -294,11 +294,11 @@ function drawInstructions(){
   let strToggleFillMode = "'f' : Toggle fill mode (" + mapBrushFillMode[brushFillMode] + ")";
   text(strToggleFillMode, xText, yText + tSize);
 }
-{% endhighlight JavaScript %}
+```
 
 Let's go back to our `draw()` function and add in the call to `drawInstructions()` but only if `showInstructions` is enabled. And note how this `drawInstructions()` call must come after drawing the offscreen buffer to the screen. That way, it will be "layered" on top.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   // Draw the current brush stroke at the given x, y position
   // But we don't draw to canvas, we draw to the offscreenGfxBuffer
@@ -312,7 +312,7 @@ function draw() {
     drawInstructions();
   }
 }
-{% endhighlight JavaScript %}
+```
 
 ### Hook up keyboard commands
 
@@ -325,7 +325,7 @@ If you carefully read the instruction code above, you may have noticed that we a
 
 We'll implement keyboard support via the [`keyPressed()`](https://p5js.org/reference/#/p5/keyPressed) method, which is called once every time a key is pressed.
 
-{% highlight JavaScript %}
+```javascript
 function keyPressed() {
   let lastFillMode = brushFillMode;
   let lastBrushType = brushType;
@@ -348,7 +348,7 @@ function keyPressed() {
     offscreenGfxBuffer.background(100);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 To clear the screen, notice how we simply overwrite the current graphics buffer with a solid background of a given color (grayscale 100 in this case): the `offscreenGfxBuffer.background(100)` call.
 
@@ -387,7 +387,7 @@ To update our p5.js PaintIO application to support web serial, we need to accomp
 
 In previous lessons we were capturing mouse clicks to initiate serial connections. Here, we will use the keyboard—specifically, the `o` key. So, let's update the `keyPressed()` function to look for the `o` key and then call `serial.connectAndOpen()`.
 
-{% highlight JavaScript %}
+```javascript
 function keyPressed(){
   ...
   }else if(key == 'o'){
@@ -400,13 +400,13 @@ function keyPressed(){
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 #### Update on-screen instructions
 
 And add in the corresponding instructions:
 
-{% highlight JavaScript %}
+```javascript
 function drawInstructions(){
   ...
   yText += tSize + yBuffer;
@@ -420,13 +420,13 @@ function drawInstructions(){
   text(strConnectToSerial, xText, yText + tSize);
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 #### Parse serial data
 
 Update the `onSerialDataReceived()` function to parse incoming data and set the variables `brushX` and `brushY`, which hold the brush's x,y coordinates in pixels as well as `lastBrushX` and `lastBrushY`, which track the previous x,y locations (similar to p5.js's [`pmouseX`](https://p5js.org/reference/#/p5/pmouseX) and [`pmouseY`](https://p5js.org/reference/#/p5/pmouseY)):
 
-{% highlight JavaScript %}
+```javascript
 function onSerialDataReceived(eventSender, newData) {
   //console.log("onSerialDataReceived", newData);
   pHtmlMsg.html("onSerialDataReceived: " + newData);
@@ -454,7 +454,7 @@ function onSerialDataReceived(eventSender, newData) {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 #### Update drawing code to use brush x,y
 
@@ -462,7 +462,7 @@ Currently, we are only drawing brush strokes at the current `mouseX` and `mouseY
 
 A keen reader will note that we are now calling `drawBrushStroke()` **twice**: once for mouse input and once for our Arduino-based controller input. Yes, that's true. But bimanual interaction with two controllers has a long history in HCI—going all the way back to Douglas Engelbart's [Mother of All Demos](https://youtu.be/B6rKUf9DWRI?si=XJNd-tspEE9IR9AU) in 1968 ([Wikipedia](https://en.wikipedia.org/wiki/The_Mother_of_All_Demos), [Computer History Museum](https://www.computerhistory.org/revolution/input-output/14/350))—and opens up many fruitful interaction possibilities! Later, we'll make the mouse as a paintbrush toggleable.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   
   // Draw the current brush stroke at the given mouse x, y position
@@ -482,7 +482,7 @@ function draw() {
     drawInstructions();
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And that's it. The full code is available in the p5.js online editor as [Paint I/O 2 - Web Serial](https://editor.p5js.org/jonfroehlich/sketches/NxUaI2hnT).
 
@@ -500,7 +500,7 @@ Now that we completed an initial PaintIO app with serial input support, it's tim
 
 The Arduino code is simple: read from the two analog input pins, normalize these readings between [0, 1] (inclusive), and transmit them over serial as a comma-separated string.
 
-{% highlight C++ %}
+```cpp
 const int X_ANALOG_INPUT_PIN = A0;
 const int Y_ANALOG_INPUT_PIN = A1;
 
@@ -530,7 +530,7 @@ void loop() {
   
   delay(10);
 }
-{% endhighlight C++ %}
+```
 
 **Code.** This code is available in our GitHub as [XYAnalogOut.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/XYAnalogOut/XYAnalogOut.ino). You can also see the OLED-based variant as [XYAnalogOutOLED.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/XYAnalogOutOLED/XYAnalogOutOLED.ino).
 {: .fs-1 }
@@ -559,7 +559,7 @@ As we're interested in exploring dual-screen interaction, let's add in an [OLED]
 
 Now, let's update our Arduino code to show the x,y location of the brush on the OLED. This will prove useful when we add in dynamic brush sizes and our brush is small in the p5.js app. The full code is in GitHub as [XYAnalogOutOLED.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/XYAnalogOutOLED/XYAnalogOutOLED.ino); however, the relevant bit is simply:
 
-{% highlight C++ %}
+```cpp
 void loop(){
   ...
 
@@ -586,7 +586,7 @@ void loop(){
 
   ...
 }
-{% endhighlight C++ %}
+```
 
 **Code.** The full code is in our GitHub as [XYAnalogOutOLED.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/XYAnalogOutOLED/XYAnalogOutOLED.ino).
 {: .fs-1 }
@@ -635,7 +635,7 @@ Let's begin by updating our parsing code to support the four incoming brush prop
 
 Update the `onSerialDataReceived()` function:
 
-{% highlight JavaScript %}
+```javascript
 function onSerialDataReceived(eventSender, newData) {
   pHtmlMsg.html("onSerialDataReceived: " + newData);
 
@@ -647,11 +647,11 @@ function onSerialDataReceived(eventSender, newData) {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And then add in the `parseBrushData()` function to parse `xPosFrac` as a float between [0, 1], `yPosFrac` as a float between [0, 1], `sizeFrac` as a float between [0, 1], `brushType` as a 0, 1, 2 corresponding to CIRCLE, SQUARE, TRIANGLE, and `brushFillMode` corresponding to FILL *vs.* OUTLINE.
 
-{% highlight JavaScript %}
+```javascript
 function parseBrushData(newData){
   // The format is xPosFrac, yPosFrac, sizeFrac, brushType, brushFillMode
   let startIndex = 0;
@@ -700,7 +700,7 @@ function parseBrushData(newData){
     brushSize = MAX_BRUSH_SIZE * brushSizeFraction;
   }
 }
-{% endhighlight JavaScript %}
+```
 
 #### Transmit brush type and fill mode
 
@@ -708,25 +708,25 @@ We support changing the brush type and fill mode both through keyboard commands 
 
 Add in a method called `serialWriteShapeData`, which is similar to what we had in [our previous lesson](p5js-serial-io.md) on bidirectional serial communication.
 
-{% highlight JavaScript %}
+```javascript
 async function serialWriteShapeData(shapeType, shapeDrawMode) {
   if (serial.isOpen()) {
     let strData = shapeType + "," + shapeDrawMode;
     serial.writeLine(strData);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And then call this function from `keyPressed()`, when necessary:
 
-{% highlight JavaScript %}
+```javascript
 function keyPressed() {
   ...
   if(lastFillMode != brushFillMode || lastBrushType != brushType){
     serialWriteShapeData(brushType, brushFillMode);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 #### Adding color
 
@@ -736,7 +736,7 @@ But, in short, we're using HSB to more easily control hue.
 
 In `setup()`, add the following:
 
-{% highlight JavaScript %}
+```javascript
 function setup(){
   ...
   // Set color mode to HSB with each value ranging from 0 to 1
@@ -746,10 +746,10 @@ function setup(){
   brushColor = color(1, 0, 1, 0.18);
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 Then, in draw, dynamically set the hue based on brush size:
-{% highlight JavaScript %}
+```javascript
 function draw() {
   
   // Set brush color
@@ -758,7 +758,7 @@ function draw() {
 
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 That's it. You can view, edit, and play with this new version of our PaintIO app [here](https://editor.p5js.org/jonfroehlich/sketches/GOvMjQr6y).
 

--- a/communication/p5js-serial-io.md
+++ b/communication/p5js-serial-io.md
@@ -65,28 +65,28 @@ We'll build this up piece-by-piece. First, we'll focus on the p5.js shape drawin
 
 Add in the following top-level variables:
 
-{% highlight JavaScript %}
+```javascript
 const MIN_SHAPE_SIZE = 10;   // minimum shape size in pixels
 const MAX_SHAPE_MARGIN = 10; // when shape is at max size, the margin to edge of canvas
 let maxShapeSize = -1;       // the maximum shape size
 let curShapeSize = 10;       // the current shape size
-{% endhighlight JavaScript %}
+```
 
 We use the prefix [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) to indicate read-only variables and [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) for block-scoped mutable variables.
 
 Now initialize the `maxShapeSize` based on the canvas width/height in `setup()`:
 
-{% highlight JavaScript %}
+```javascript
 function setup(){
   ...
   maxShapeSize = min(width, height) - MAX_SHAPE_MARGIN;
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 Update the `draw()` function to actually draw our shape (a circle, for now).
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
 
@@ -96,11 +96,11 @@ function draw() {
   const yCenter = height / 2;
   circle(xCenter, yCenter, curShapeSize);
 }
-{% endhighlight JavaScript %}
+```
 
 Finally, we need to change `curShapeSize` based on the x position of the mouse:
 
-{% highlight JavaScript %}
+```javascript
 function mouseMoved(){
   curShapeSize = map(mouseX, 0, width, MIN_SHAPE_SIZE, maxShapeSize);
 
@@ -109,7 +109,7 @@ function mouseMoved(){
   // your circle may grow larger than you expect. Try it out!
   curShapeSize = constrain(curShapeSize, MIN_SHAPE_SIZE, maxShapeSize);
 }
-{% endhighlight JavaScript %}
+```
 
 That's it! We made an initial interactive shape app. Save your work and try it out with VSCode's [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) or simply hit the `play` button in the p5.js editor.
 
@@ -125,7 +125,7 @@ Now, let's add in support for rendering more shapes: the square and triangle. We
 
 To track the current shape type, we'll use a JavaScript [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)—a flexible, foundational [data type in JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures). Anything that is not a [primitive data type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#data_and_structure_types) in JavaScript—*e.g.,* things that are not a [String](https://developer.mozilla.org/en-US/docs/Glossary/String), [Boolean](https://developer.mozilla.org/en-US/docs/Glossary/Boolean), [Number](https://developer.mozilla.org/en-US/docs/Glossary/Number), *etc.*—is a JavaScript [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object). In this case, we'll simply treat this Object as a key/value store, so let's call it `mapShapeTypeToShapeName` where the variable indicates "mapping" a shape type (0, 1, 2) to a shape name (circle, square, triangle). And we'll track the current shape type via `curShapeType`.
 
-{% highlight JavaScript %}
+```javascript
 const mapShapeTypeToShapeName = {
   0: "Circle",
   1: "Square",
@@ -133,13 +133,13 @@ const mapShapeTypeToShapeName = {
 };
 
 let curShapeType = 0;        // track current shape type
-{% endhighlight JavaScript %}
+```
 
 So, `mapShapeTypeToShapeName` defines the three shapes and their key/value relationship and `curShapeType` tracks the current shape as 0 (for circle), 1 (for square), and 2 (for triangle).
 
 For selecting the shape type, there are many possibilities—we could draw small iconic representations of a circle, square, and triangle and switch shape types when these are clicked (like buttons). But we'll do something even simpler: increment `curShapeType` on each mouse click.
 
-{% highlight JavaScript %}
+```javascript
 function mouseClicked() {
   curShapeType++;
   if(curShapeType >= Object.keys(mapShapeTypeToShapeName).length){
@@ -152,10 +152,10 @@ function mouseClicked() {
   //  serial.connectAndOpen(null, serialOptions);
   //}
 }
-{% endhighlight JavaScript %}
+```
 
 Finally, we need to update our `draw()` function to draw the three shape types:
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
   fill(250);
@@ -185,11 +185,11 @@ function draw() {
       triangle(x1, y1, x2, y2, x3, y3)
   }
 }
-{% endhighlight JavaScript %}
+```
 
 For user friendliness, let's drop in some instructions as well. At the end of the draw() function, display some text that says "Mouse click to change the shape":
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   ...
 
@@ -203,7 +203,7 @@ function draw() {
   const xText = width / 2 - tWidth / 2;
   text(strInstructions, xText, height - tSize + 6);
 }
-{% endhighlight JavaScript %}
+```
 
 Alright, we did it! Now check out your work by loading it with Live Server or in the p5.js online editor. Here's [a live demo](https://editor.p5js.org/jonfroehlich/sketches/v3xWP3Np1):
 
@@ -217,7 +217,7 @@ Finally, the last piece is to output shape type and shape size via web serial. T
 
 First, let's add a serial write function called `serialWriteShapeData(shapeType, shapeSize)`, which takes in a shape type and shape size and outputs them over web serial as text-encoded data.
 
-{% highlight JavaScript %}
+```javascript
 async function serialWriteShapeData(shapeType, shapeSize) {
   if (serial.isOpen()) {
     // Convert the shape size into a fraction between [0, 1] inclusive
@@ -229,13 +229,13 @@ async function serialWriteShapeData(shapeType, shapeSize) {
     serial.writeLine(strData);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Notably, we convert the shape size, which is in pixels, to a normalized value between [0, 1] called `shapeSizeFraction`—this is what we'll transmit over serial and interpret on the Arduino side.
 
 Now, let's update the `mouseClicked()` function to handle opening and connecting with web serial or, if a connection has been made, to increment `curShapeType` and send that new data over serial by calling our new `serialWriteShapeData()` function.
 
-{% highlight JavaScript %}
+```javascript
 function mouseClicked() {
   if (!serial.isOpen()) {
     // If the serial connection is not opened, begin open/connect sequence
@@ -255,11 +255,11 @@ function mouseClicked() {
     serialWriteShapeData(curShapeType, curShapeSize);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Let's also update the instructions to the user so they know that mouse clicking is state dependent:
 
-{% highlight JavaScript %}
+```javascript
 function draw(){
   ...
   // Some instructions to the user
@@ -277,11 +277,11 @@ function draw(){
   const xText = width / 2 - tWidth / 2;
   text(strInstructions, xText, height - tSize + 6);
 }
-{% endhighlight JavaScript %}
+```
 
 Finally, we need to update the `mouseMoved()` method to call `serialWriteShapeData()` on a new shape size:
 
-{% highlight JavaScript %}
+```javascript
 function mouseMoved(){
   let lastShapeSize = curShapeSize;
   curShapeSize = map(mouseX, 0, width, MIN_SHAPE_SIZE, maxShapeSize);
@@ -291,7 +291,7 @@ function mouseMoved(){
     serialWriteShapeData(curShapeType, curShapeSize);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And we're done with the p5.js app! You can view, edit, play with the code in the [p5.js online editor ](https://editor.p5js.org/jonfroehlich/sketches/TfE1BjOX6) or from our GitHub ([live page](https://makeabilitylab.github.io/p5js/WebSerial/p5js/DisplayShapeOut/), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/DisplayShapeOut)).
 
@@ -320,18 +320,18 @@ Let's begin our Arduino app simply by echo'ing the incoming data back on serial.
 
 So, instead, let's program our p5.js app to read incoming serial data and print it out—a web-based Serial Monitor! Luckily, our p5.js [`SerialTemplate`](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/SerialTemplate) code already does that. In the template, we simply have:
 
-{% highlight JavaScript %}
+```javascript
 function onSerialDataReceived(eventSender, newData) {
   console.log("onSerialDataReceived", newData);
   pHtmlMsg.html("onSerialDataReceived: " + newData);
 }
-{% endhighlight JavaScript %}
+```
 
 Which prints incoming data sent by Arduino to console and also updates the handy `pHtmlMsg` HTML element so you can see the info on your webpage (you could comment this out, of course).
 
 So, the simplest Arduino sketch to start with could be an "echo back" program like:
 
-{% highlight C++ %}
+```cpp
 const long BAUD_RATE = 115200;
 void setup() {
   Serial.begin(BAUD_RATE);
@@ -349,7 +349,7 @@ void loop() {
     Serial.println("'");
   }
 }
-{% endhighlight C++ %}
+```
 
 **Code.** Simple serial echo back program for Arduino ([EchoBackSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/EchoBackSerialIn/EchoBackSerialIn.ino) on GitHub).
 {: .fs-1 }
@@ -403,7 +403,7 @@ We'll wire up the OLED using I<sup>2</sup>C as we did in our [OLED](../advancedi
 
 Now, let's program the OLED to print out some debugging information. Add the following OLED-required declarations at the top:
 
-{% highlight C++ %}
+```cpp
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
@@ -414,11 +414,11 @@ Now, let's program the OLED to print out some debugging information. Add the fol
 // Declaration for an SSD1306 display connected to I2C (SDA, SCL pins)
 #define OLED_RESET     4 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 _display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
-{% endhighlight C++ %}
+```
 
 In `setup()`, initialize the OLED and print out a "Waiting for serial..." message. We'll also show the baud rate, which is a useful reminder in case you set a different value on the p5.js side.
 
-{% highlight C++ %}
+```cpp
 const long BAUD_RATE = 115200;
 void setup() {
   Serial.begin(BAUD_RATE);
@@ -440,11 +440,11 @@ void setup() {
   _display.print(" bps");
   _display.display();
 }
-{% endhighlight C++ %}
+```
 
 Now, in `loop()`, add in the OLED-based debug printouts:
 
-{% highlight C++ %}
+```cpp
 void loop() {
   // Check to see if there is any incoming serial data
   if(Serial.available() > 0){
@@ -468,7 +468,7 @@ void loop() {
     Serial.println("'");
   }
 }
-{% endhighlight C++ %}
+```
 
 Here's a video demonstration of what we have so far: the full DisplayShapeOut p5.js app ([live page](https://makeabilitylab.github.io/p5js/WebSerial/p5js/DisplayShapeOut/), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/DisplayShapeOut)) running with an intermediate version of [DisplayShapeSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/DisplayShapeSerialIn-Intermediate1/DisplayShapeSerialIn-Intermediate1.ino), which simply echos back received data and displays some debugging output to the OLED screen.
 
@@ -488,7 +488,7 @@ Update the code inside of `if(Serial.available() > 0)` in `loop()` to include pa
 
 For now, we'll display both the raw data received over serial as well as the parsed data. Once we're confident we have this working, we'll remove this debug output.
 
-{% highlight C++ %}
+```cpp
 String rcvdSerialData = Serial.readStringUntil('\n'); 
 
 // Parse out the comma separated string
@@ -516,7 +516,7 @@ if(indexOfComma != -1){
   _display.print(curShapeSizeFraction);
   _display.display();
 } 
-{% endhighlight C++ %}
+```
 
 Great, now let's upload this to the Arduino and test our two apps thus far. Does the parsing work?
 
@@ -546,7 +546,7 @@ Let's pivot from reading and parsing serial input to writing our OLED-based draw
 
 First, let's introduce some shape related types and variables:
 
-{% highlight C++ %}
+```cpp
 // New enum for tracking shape types
 enum ShapeType {
   CIRCLE,
@@ -560,21 +560,21 @@ float _curShapeSizeFraction = -1; // tracks current shape fraction
 
 const int MIN_SHAPE_SIZE = 4;     // min shape size
 int _maxShapeSize;                // max shape size (dependent on display width/height)
-{% endhighlight C++ %}
+```
 
 We also need to initialize `_maxShapeSize` in `setup()`:
 
-{% highlight C++ %}
+```cpp
 void setup(){
   ...
   _maxShapeSize = min(_display.width(), _display.height());
   ...
 }
-{% endhighlight C++ %}
+```
 
 Update our relevant parsing code to use our new global variables `_curShapeType` and `_curShapeSizeFraction`. Let's also add in some boundary checking to ensure that the shape size fraction is between [0, 1].
 
-{% highlight C++ %}
+```cpp
 ...
 if(indexOfComma != -1){
   // Parse out the shape type, which should be 0 (circle), 1 (square), 2 (triangle)
@@ -594,11 +594,11 @@ if(indexOfComma != -1){
   }
 }
 ...
-{% endhighlight C++ %}
+```
 
 Now, let's add our `drawShape(ShapeType shapeType, float fractionSize)` function, which draws a circle, square, or triangle depending on the passed in `shapeType` at the appropriate size (`fractionSize`).
 
-{% highlight C++ %}
+```cpp
 void drawShape(ShapeType shapeType, float fractionSize){
   _display.clearDisplay();
 
@@ -629,11 +629,11 @@ void drawShape(ShapeType shapeType, float fractionSize){
 
   _display.display();
 }
-{% endhighlight C++ %}
+```
 
 Finally, we need to call `drawShape()`, which we'll do so at the end of `loop()`:
 
-{% highlight C++ %}
+```cpp
 void loop() {
   ...
 
@@ -642,7 +642,7 @@ void loop() {
     drawShape(_curShapeType, _curShapeSizeFraction);
   }
 }
-{% endhighlight C++ %}
+```
 
 That's it! You can see our full implementation on GitHub as [DisplayShapeSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/DisplayShapeSerialIn/DisplayShapeSerialIn.ino).
 
@@ -680,20 +680,20 @@ To begin, make a copy of the `DisplayShapeOut` p5.js folder and rename it to som
 
 For the fill *vs.* outline draw mode, we'll add in an additional state tracking variable called `curShapeDrawMode`:
 
-{% highlight JavaScript %}
+```javascript
 const mapShapeDrawMode = {
   0: "Fill",
   1: "Outline",
 };
 
 let curShapeDrawMode = 0; // Fill as default
-{% endhighlight JavaScript %}
+```
 
 The draw mode can be set either by **right clicking** the mouse or from incoming Arduino data (from web serial). Let's handle the former (right-mouse clicking) first. 
 
 According to [the p5.js docs](https://p5js.org/reference/#/p5/mouseClicked), the `mouseClicked()` function is only guaranteed to be called when the left mouse button is pressed and released. Thus, we cannot rely on this [`mouseClicked()`](https://p5js.org/reference/#/p5/mouseClicked) for changing the draw mode. Instead, we'll add our state tracking into [`mousePressed()`](https://p5js.org/reference/#/p5/mousePressed).
 
-{% highlight JavaScript %}
+```javascript
 function mousePressed() {
   // Only update states if we're connected to serial
   if (serial.isOpen()) {
@@ -712,7 +712,7 @@ function mousePressed() {
     serialWriteShapeData(curShapeType, curShapeSize, curShapeDrawMode);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Notice that we also moved the `shapeType` tracking here too.
 
@@ -720,7 +720,7 @@ Notice that we also moved the `shapeType` tracking here too.
 
 In `draw()`, update the instructions to the user to include info about both left-clicking and right-clicking:
 
-{% highlight JavaScript %}
+```javascript
 function draw(){
   ...
 
@@ -739,13 +739,13 @@ function draw(){
   const xText = width / 2 - tWidth / 2;
   text(strInstructions, xText, height - tSize + 6);
 }
-{% endhighlight JavaScript %}
+```
 
 #### Update the serialWriteShapeData function and callers
 
 We also need to update our `serialWriteShapeData()` function to receive and write out three variables: `shapeType`, `shapeSize`, and `shapeDrawMode` instead of two as before:
 
-{% highlight JavaScript %}
+```javascript
 async function serialWriteShapeData(shapeType, shapeSize, shapeDrawMode) {
   if (serial.isOpen()) {
     let shapeSizeFraction = (shapeSize - MIN_SHAPE_SIZE) / (maxShapeSize - MIN_SHAPE_SIZE);
@@ -757,17 +757,17 @@ async function serialWriteShapeData(shapeType, shapeSize, shapeDrawMode) {
     serial.writeLine(strData);
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And make sure to also update the `serialWriteShapeData()` call in `mouseMoved()` to use three parameters as well:
 
-{% highlight JavaScript %}
+```javascript
 function mouseMoved() {
   ...
   serialWriteShapeData(curShapeType, curShapeSize, curShapeDrawMode);
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 #### Add onSerialDataReceived parsing code
 
@@ -775,17 +775,17 @@ Finally, we need to add code that parses incoming serial data into `shapeType`, 
 
 Recall that our web serial library has an event called `SerialEvents.DATA_RECEIVED`, which we subscribe to in `setup()` and hook up a method called `onSerialDataReceived(newData)`:
 
-{% highlight JavaScript %}
+```javascript
 function setup() {
   ...
   serial.on(SerialEvents.DATA_RECEIVED, onSerialDataReceived);
   ...
 }
-{% endhighlight JavaScript %}
+```
 
 Let's now update that `onSerialDataReceived` method!
 
-{% highlight JavaScript %}
+```javascript
 function onSerialDataReceived(eventSender, newData) {
   //console.log("onSerialDataReceived", newData);
   pHtmlMsg.html("onSerialDataReceived: " + newData);
@@ -813,7 +813,7 @@ function onSerialDataReceived(eventSender, newData) {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 And that's it! Here's our full implementation as [DisplayShapeBidirectional](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/DisplayShapeBidirectional) in GitHub ([live page here](http://makeabilitylab.github.io/p5js/WebSerial/p5js/DisplayShapeBidirectional)).
 
@@ -829,7 +829,7 @@ Shifting now to the Arduino side. Let's add in two buttons to our Arduino circui
 
 For the code, let's begin by adding draw mode support:
 
-{% highlight C++ %}
+```cpp
 enum DrawMode{
   FILL,
   OUTLINE,
@@ -837,11 +837,11 @@ enum DrawMode{
 };
 
 DrawMode _curDrawMode = FILL;
-{% endhighlight C++ %}
+```
 
 And update our `drawShape()` function to accept three variables and draw the shapes accordingly (either **filled** or as **outlines**):
 
-{% highlight C++ %}
+```cpp
 void drawShape(ShapeType shapeType, float fractionSize, DrawMode curDrawMode){
   _display.clearDisplay();
 
@@ -883,13 +883,13 @@ void drawShape(ShapeType shapeType, float fractionSize, DrawMode curDrawMode){
 
   _display.display();
 }
-{% endhighlight C++ %}
+```
 
 ### Add in support for buttons
 
 Add in a new method called `checkButtonPresses()` that reads the two buttons, sets the global variables `_curShapeType` and `_curDrawMode` accordingly, and sends them over serial.
 
-{% highlight C++ %}
+```cpp
 void checkButtonPresses(){
   // Read the shape selection button (active LOW)
   int shapeSelectionButtonVal = digitalRead(SHAPE_SELECTION_BUTTON_PIN);
@@ -928,7 +928,7 @@ void checkButtonPresses(){
   _lastShapeSelectionButtonVal = shapeSelectionButtonVal;
   _lastDrawModeButtonVal = shapeDrawModeButtonVal;
 }
-{% endhighlight C++ %}
+```
 
 We can test our new button and drawing code regardless of serial input. So, let's do that now:
 
@@ -942,7 +942,7 @@ We can test our new button and drawing code regardless of serial input. So, let'
 
 Finally, we need to update the serial parsing code to parse three comma separated values rather than just two: `shapeType`, `shapeSizeFraction`, and `drawMode`. Let's move all of this serial code into its own function called `checkAndParseSerial()`:
 
-{% highlight C++ %}
+```cpp
 void checkAndParseSerial(){
   // Check to see if there is any incoming serial data
   if(Serial.available() > 0){
@@ -987,11 +987,11 @@ void checkAndParseSerial(){
     Serial.println("'");
   }
 }
-{% endhighlight C++ %}
+```
 
 And now the full `loop()` looks like:
 
-{% highlight C++ %}
+```cpp
 void loop() {
   checkAndParseSerial();
   checkButtonPresses();
@@ -1002,7 +1002,7 @@ void loop() {
     drawShape(_curShapeType, _curShapeSizeFraction, _curDrawMode);
   }
 }
-{% endhighlight C++ %}
+```
 
 We did it! Below, we provide the full code links and a video demonstration.
 

--- a/communication/p5js-serial.md
+++ b/communication/p5js-serial.md
@@ -192,20 +192,20 @@ If you prefer to **configure VSCode manually**, the key challenge is getting aut
 
 First, open a terminal in your project folder and run:
 
-{% highlight Bash %}
+```bash
 npm init -y
 npm install --save-dev @types/p5
-{% endhighlight Bash %}
+```
 
 Then create a `jsconfig.json` file in your project root:
 
-{% highlight JSON %}
+```json
 {
   "compilerOptions": {
     "types": ["p5/global"]
   }
 }
-{% endhighlight JSON %}
+```
 
 That's it! VSCode will now provide autocomplete, hover documentation, and parameter hints for all p5.js functions. You'll still need [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) to serve your sketch in a browser.
 
@@ -244,7 +244,7 @@ The Arduino program is simple: read an analog value and transmit it via serial a
 
 We use [`analogRead()`](https://www.arduino.cc/reference/en/language/functions/analog-io/analogRead/) on Pin A0 and divide the reading by the maximum analog input value (1023 on the Arduino Uno and Leonardo with 10-bit ADCs, or 4095 on ESP32 boards with 12-bit ADCs). We set the baud rate to 115200.
 
-{% highlight C %}
+```cpp
 const int DELAY_MS = 5;
 
 const int ANALOG_INPUT_PIN = A0;
@@ -270,7 +270,7 @@ void loop() {
   _lastAnalogVal = analogVal;
   delay(DELAY_MS);
 }
-{% endhighlight C %}
+```
 
 **Code.** The full code is [AnalogOut.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/AnalogOut/AnalogOut.ino) in our GitHub.
 {: .fs-1 }
@@ -287,13 +287,13 @@ Start with a brand new blank project with `index.html`, `css/style.css`, and `sk
 
 If you have [p5.vscode](https://marketplace.visualstudio.com/items?itemName=samplavigne.p5-vscode) installed, you can create a new project from the Command Palette (`Ctrl+Shift+P` → `Create p5.js Project`). If you do this, make sure you add our serial library to the `<head>` in `index.html`:
 
-{% highlight HTML %}
+```html
 <script src="https://cdn.jsdelivr.net/gh/makeabilitylab/js@main/dist/makelab.serial.iife.js"></script>
-{% endhighlight HTML %}
+```
 
 Or you can build up the required files manually. The `index.html` should look like:
 
-{% highlight HTML %}
+```html
 <!DOCTYPE html>
 <html>
 
@@ -309,14 +309,14 @@ Or you can build up the required files manually. The `index.html` should look li
 </body>
 
 </html>
-{% endhighlight HTML %}
+```
 
 {: .note }
 > Notice that we're pinning to **p5.js version 1.11.13** (`p5@1.11.13`) rather than using the latest version. This ensures your sketch continues to work even after the p5.js Editor [defaults to 2.0 in August 2026](#p5js-20). You can also use `p5@1` to always get the latest 1.x release.
 
 The `css/style.css` file:
 
-{% highlight CSS %}
+```css
 html, body {
   margin: 0;
   padding: 0;
@@ -325,11 +325,11 @@ html, body {
 canvas {
   display: block;
 }
-{% endhighlight CSS %}
+```
 
 And the `sketch.js` file:
 
-{% highlight JavaScript %}
+```javascript
 function setup() {
   createCanvas(400, 400);
 }
@@ -337,7 +337,7 @@ function setup() {
 function draw() {
   background(100);
 }
-{% endhighlight JavaScript %}
+```
 
 Now save and load the page with Live Server. It should look like this:
 
@@ -351,7 +351,7 @@ If your page does not load or does not look like this, study our blank template 
 
 Let's update `sketch.js` to draw a white circle of diameter 50 in the canvas center. We'll use [`fill()`](https://p5js.org/reference/#/p5/fill) to set the fill color and [`noStroke()`](https://p5js.org/reference/#/p5/noStroke) to turn off outlining.
 
-{% highlight JavaScript %}
+```javascript
 function setup() {
   createCanvas(400, 400);
 }
@@ -368,7 +368,7 @@ function draw() {
   let circleDiameter = 50;
   circle(xCenter, yCenter, circleDiameter);
 }
-{% endhighlight JavaScript %}
+```
 
 It should look like this:
 
@@ -382,7 +382,7 @@ Or here's [a live demo](https://editor.p5js.org/jonfroehlich/sketches/aPoybLEdC)
 
 Now let's make this sketch interactive! We'll set the circle's size based on the mouse's x position. Later, we'll replace the mouse input with **incoming serial data**.
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
   
@@ -399,7 +399,7 @@ function draw() {
   let circleDiameter = maxDiameter * shapeFraction;
   circle(xCenter, yCenter, circleDiameter);
 }
-{% endhighlight JavaScript %}
+```
 
 It should look something like this:
 
@@ -417,16 +417,16 @@ Now we can add serial functionality. This is very similar to the [previous lesso
 
 First, add global variables to the top of `sketch.js`:
 
-{% highlight JavaScript %}
+```javascript
 let shapeFraction = 0; // tracks the new shape fraction off serial
 let serial;            // the Serial object
 let serialOptions = { baudRate: 115200 };
 let pHtmlMsg;          // used for displaying messages via html (optional)
-{% endhighlight JavaScript %}
+```
 
 Then create the Serial object in `setup()`, set up callbacks, and attempt to auto-connect to previously approved ports:
 
-{% highlight JavaScript %}
+```javascript
 function setup() {
   createCanvas(400, 400);
 
@@ -443,11 +443,11 @@ function setup() {
   // Add in a lil <p> element to provide messages. This is optional
   pHtmlMsg = createP("Click anywhere on this page to open the serial connection dialog");
 }
-{% endhighlight JavaScript %}
+```
 
 Next, add the callback functions:
 
-{% highlight JavaScript %}
+```javascript
 function onSerialErrorOccurred(eventSender, error) {
   console.log("onSerialErrorOccurred", error);
   pHtmlMsg.html(error);
@@ -467,11 +467,11 @@ function onSerialDataReceived(eventSender, newData) {
   console.log("onSerialDataReceived", newData);
   pHtmlMsg.html("onSerialDataReceived: " + newData);
 }
-{% endhighlight JavaScript %}
+```
 
 Finally, add `mouseClicked()` to let the user connect to serial by clicking anywhere on the canvas:
 
-{% highlight JavaScript %}
+```javascript
 function mouseClicked() {
   if (!serial.isOpen()) {
     try {
@@ -481,7 +481,7 @@ function mouseClicked() {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 Save and run. The page should look the same except for the new `<p>` element at the bottom saying "Click anywhere on this page to open the serial connection dialog."
 
@@ -491,7 +491,7 @@ Save and run. The page should look the same except for the new `<p>` element at 
 
 Finally, we need to parse the incoming serial data and use it to control the circle size. Update `onSerialDataReceived()` to store the incoming value:
 
-{% highlight JavaScript %}
+```javascript
 function onSerialDataReceived(eventSender, newData) {
   console.log("onSerialDataReceived", newData);
   pHtmlMsg.html("onSerialDataReceived: " + newData);
@@ -499,11 +499,11 @@ function onSerialDataReceived(eventSender, newData) {
   // Parse the incoming value as a float
   shapeFraction = parseFloat(newData);
 }
-{% endhighlight JavaScript %}
+```
 
 And in `draw()`, simply comment out the mouse-based line since `shapeFraction` is now set by serial:
 
-{% highlight JavaScript %}
+```javascript
 function draw() {
   background(100);
   
@@ -520,7 +520,7 @@ function draw() {
   let circleDiameter = maxDiameter * shapeFraction;
   circle(xCenter, yCenter, circleDiameter);
 }
-{% endhighlight JavaScript %}
+```
 
 And that's it! We did it! You can view, edit, and run CircleSizeIn in the [p5.js online editor](https://editor.p5js.org/jonfroehlich/sketches/5Knw4tN1d) or via GitHub ([live page](http://makeabilitylab.github.io/p5js/WebSerial/p5js/CircleSizeInDemo), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/CircleSizeInDemo)).
 
@@ -572,7 +572,7 @@ We're going to use a **queue** to temporarily store data coming off serial, then
 
 The full code is ~50 lines:
 
-{% highlight JavaScript %}
+```javascript
 let serial; // the Serial object
 let serialOptions = { baudRate: 115200 };
 let queue = [];
@@ -636,7 +636,7 @@ function mouseClicked() {
     }
   }
 }
-{% endhighlight JavaScript %}
+```
 
 That's it! Pretty amazing, huh?! You can view our implementation as a [live page](https://makeabilitylab.github.io/p5js/WebSerial/p5js/GraphIn/) or [on GitHub](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/GraphIn).
 

--- a/communication/serial-intro.md
+++ b/communication/serial-intro.md
@@ -42,10 +42,10 @@ We've been using [Arduino's serial](https://www.arduino.cc/reference/en/language
 
 On Arduino, we initialize the serial port using [`Serial.begin()`](https://docs.arduino.cc/language-reference/en/functions/communication/serial/begin/). The [`Serial.begin()`](https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/HardwareSerial.cpp) function has two overloaded options:
 
-{% highlight C %}
+```cpp
 begin(unsigned long baud)
 begin(unsigned long baud, byte config)
-{% endhighlight C %}
+```
 
 Thus far, in our lessons, we have been using the first function—`begin(unsigned long baud)`—which sets the data rate in bits per second (baud). But what about the second function with `byte config` and what does this parameter mean? We'll dig into both below.
 
@@ -143,20 +143,20 @@ With serial communication, we can either transmit/receive data as a series of bi
 
 To read binary data with Arduino, use [`readBytes()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readBytes/) or [`readBytesUntil()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readBytesUntil/):
 
-{% highlight C %}
+```cpp
 size_t readBytes(byte *buffer, size_t length)
 size_t readBytesUntil(byte terminator, byte *buffer, size_t length)
-{% endhighlight C %}
+```
 
 [`Serial.readBytes()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readBytes/) reads bytes from the serial port into a buffer and terminates if the determined length has been read or it times out (see [`Serial.setTimeout()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/setTimeout/)). [`Serial.readBytesUntil()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readBytesUntil/) is similar but also accepts a terminator parameter—if the terminator byte is detected, the function returns all bytes up to (but not including) the terminator. Both functions return the number of bytes read.
 
 To write binary data, use [`Serial.write()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/write/), which is an overloaded function:
 
-{% highlight C %}
+```cpp
 size_t write(byte val);                  // value to send as a single byte
 size_t write(String str);                // string to send as a series of bytes
 size_t write(byte *buffer, size_t length); // an array and number of bytes in buffer
-{% endhighlight C %}
+```
 
 All three [`Serial.write()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/write/) functions return the number of bytes written.
 
@@ -166,10 +166,10 @@ Reading and writing ASCII-encoded data should feel more familiar. For [serial-ba
 
 To read ASCII data, use [`Serial.readString()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readString/) and [`Serial.readStringUntil()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readStringUntil/):
 
-{% highlight C %}
+```cpp
 String readString();
 String readStringUntil(char terminator)
-{% endhighlight C %}
+```
 
 Both functions read characters from the serial buffer and store them in a String. [`Serial.readString()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readString/) terminates when it times out (see [`Serial.setTimeout()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/setTimeout/)). [`Serial.readStringUntil()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/readStringUntil/) terminates either on timeout or when a terminator character is found.
 
@@ -185,19 +185,19 @@ Why might we want to use **binary** vs. **text** encodings? If we are transmitti
 
 Let's look at a concrete example. Say we want to transmit a value that ranges between 0 and 255 from our Arduino to our computer. Because the value only ranges from 0 to 255, we can encode this in 8 bits—a single byte (`0000 0000` to `1111 1111`, or `0x00` to `0xFF` in hexadecimal). Sending via binary:
 
-{% highlight C %}
+```cpp
 byte signalVal = getSignal();
 Serial.write(signalVal);
-{% endhighlight C %}
+```
 
 So, if `getSignal()` returns 15, we transmit `0000 1111` (`0x0F`)—just one byte. If it returns 127, we transmit `0111 1111` (`0x7F`). If 255, then `1111 1111` (`0xFF`).
 
 However, we could also transmit this using ASCII-encoded data with [`Serial.println()`](https://www.arduino.cc/reference/en/language/functions/communication/serial/println/):
 
-{% highlight C %}
+```cpp
 byte signalVal = getSignal();
 Serial.println(signalVal);
-{% endhighlight C %}
+```
 
 Now if `getSignal()` returns 15, we need to transmit **four bytes** rather than just one. Using the [ASCII chart](https://www.asciichart.com/), the ASCII encoding for '1' is 49 (`0x31`) and '5' is 53 (`0x35`). Then, `Serial.println()` adds a carriage return '\r' (ASCII 13, `0x0D`) and a newline '\n' (ASCII 10, `0x0A`).
 
@@ -248,7 +248,7 @@ Again, it's completely up to you! If you're using ASCII-encoded data, you could 
 
 As you'll commonly see in our demo code, we use a simple CSV format like this:
 
-{% highlight C %}
+```cpp
 int sensorVal1 = analogRead(SENSOR1_INPUT_PIN);
 int sensorVal2 = analogRead(SENSOR2_INPUT_PIN);
 int sensorVal3 = analogRead(SENSOR3_INPUT_PIN);
@@ -257,13 +257,13 @@ Serial.print(",");
 Serial.print(sensorVal2);
 Serial.print(",");
 Serial.println(sensorVal3);
-{% endhighlight C %}
+```
 
 For example, if `sensorVal1` is 896, `sensorVal2` is 943, and `sensorVal3` is 349, then the above code would send a text string that looks like `896,943,349\r\n`.
 
 On the receiving end, we can write our own parsing code like this:
 
-{% highlight C %}
+```cpp
 if(Serial.available() > 0){
     // If we're here, then serial data has been received
     // Read data off the serial port until we get to the endline delimiter ('\n')
@@ -293,7 +293,7 @@ if(Serial.available() > 0){
         // Do stuff with sensor values
     } 
 }
-{% endhighlight C %}
+```
 
 This example assumes that data arrives in the order `sensorVal1, sensorVal2, sensorVal3` and that each received line follows the same format. To make this communication scheme more flexible, you could transmit key-value pairs like `sensorVal1=896,sensorVal2=943,sensorVal3=349`. The receiver would then parse both the variable names and their values. You could even use JSON for more complex data structures.
 
@@ -317,7 +317,7 @@ In all of our serial lessons—including this one—we'll have the Arduino trans
 
 For our examples below, we will run a simple program on the Arduino that reads ASCII-encoded data off of the serial port, parses it into an integer, and uses `analogWrite` to output that integer to an output pin. We have an LED with a current-limiting resistor connected to `OUTPUT_PIN`, which is set to `LED_BUILTIN` (Pin 13 on the Arduino Uno and Leonardo). The entire program:
 
-{% highlight C %}
+```cpp
 const int DELAY_MS = 5;
 const int OUTPUT_PIN = LED_BUILTIN;
 
@@ -352,7 +352,7 @@ void loop() {
 
   delay(DELAY_MS);
 }
-{% endhighlight C %}
+```
 
 **Code.** This code is available as [SimpleSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/SimpleSerialIn/SimpleSerialIn.ino) on GitHub. We will actually be using [SimpleSerialInOLED.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/SimpleSerialInOLED/SimpleSerialInOLED.ino) in our videos.
 {: .fs-1}
@@ -391,12 +391,12 @@ Here's a video demonstration of sending ASCII-encoded text via [Serial Monitor](
 
 Notice how we are able to see what the Arduino receives because the Arduino code echoes the received data back over serial using `Serial.print`. This is optional but helpful!
 
-{% highlight C %}
+```cpp
 // Just for debugging, echo the data back on serial
 Serial.print("Arduino received: '");
 Serial.print(rcvdSerialData);
 Serial.println("'");
-{% endhighlight C %}
+```
 
 ### Command line tools
 
@@ -411,44 +411,44 @@ On Windows, we can use the [PowerShell](https://docs.microsoft.com/en-us/powersh
 
 First, to find the available serial ports, we can use `getportnames()`:
 
-```
+```text
 PS> [System.IO.Ports.SerialPort]::getportnames()
 COM7
 ```
 
 Then, create a `SerialPort` object, which takes the COM port, the baud rate, and serial configuration parameters (parity, data bit length, and stop bit):
 
-```
+```text
 PS> $port= new-Object System.IO.Ports.SerialPort COM7,9600,None,8,one
 ```
 
 Now open this port:
 
-```
+```text
 PS> $port.open()
 ```
 
 Write to the port using ASCII-encoded text with `WriteLine(<str>)`:
 
-```
+```text
 PS> $port.WriteLine("Hello!")
 ```
 
 Similarly, to read from the port, use `ReadLine()`:
 
-```
+```text
 PS> $port.ReadLine()
 Arduino received: 'Hello!'
 ```
 Finally, to close the port, use `Close()`:
 
-```
+```text
 PS> $port.Close()
 ```
 
 Thus, the full program is simply:
 
-```
+```text
 $port= new-Object System.IO.Ports.SerialPort COM7,9600,None,8,one
 $port.open()
 $port.WriteLine("Hello!")
@@ -470,7 +470,7 @@ On Mac and Linux, we can use the `screen` command as described by this [Sparkfun
 
 First, we need to enumerate the available ports. Type:
 
-```
+```text
 > ls /dev/tty.*
 
 /dev/tty.Bluetooth-Incoming-Port /dev/tty.SLAB_USBtoUART
@@ -479,7 +479,7 @@ First, we need to enumerate the available ports. Type:
 
 In this case, the Arduino is listed as `/dev/tty.SLAB_USBtoUART`. We can connect to it via screen by typing `screen <port_name> <baud_rate>`:
 
-```
+```text
 > screen /dev/tty.SLAB_USBtoUART 9600
 ```
 
@@ -493,7 +493,7 @@ Finally, let's write a simple program in [Python](https://www.python.org/) to co
 
 For serial communication with Python, we'll use the [pySerial](https://pyserial.readthedocs.io/en/latest/) library. With Python 3 installed, open your terminal and type:
 
-```
+```text
 > pip3 install pyserial
 ```
 
@@ -503,55 +503,55 @@ Let's write a quick Python program to communicate with [SimpleSerialIn.ino](http
 
 First, import the required libraries and create a pySerial `Serial` object:
 
-{% highlight Python %}
+```python
 import serial # from https://pyserial.readthedocs.io
 import time
 
 # Create serial object on COM13 with 9600 baud and a read timeout
 # of one second (can be a float value, so 1.5 would be 1.5s)
 ser = serial.Serial(port='COM13', baudrate=9600, timeout=1)
-{% endhighlight Python %}
+```
 
 Now, ask the user to input a number between 0 and 255:
 
-{% highlight Python %}
+```python
 # Ask user for number between 0 and 255 and store in num
 num = input("Enter a number (0 - 255): ")
-{% endhighlight Python %}
+```
 
 Encode this data as a string. You can force ASCII encoding via `num.encode("ascii", "ignore")`:
 
-{% highlight Python %}
+```python
 # Encode numeric value as a string
 strNum = str.encode(num)
-{% endhighlight Python %}
+```
 
 Now send the data using pySerial's [`write(<data>)`](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.write) function. We append a newline (`\n`) so the Arduino's `Serial.readStringUntil('\n')` returns immediately rather than waiting for its 1-second timeout:
 
-{% highlight Python %}
+```python
 # Send the data using pyserial write method
 # We append '\n' so the Arduino's readStringUntil('\n') returns immediately
 print("Sending...", strNum)
 ser.write(strNum + b'\n')
 time.sleep(0.05) # sleep for 0.05s
-{% endhighlight Python %}
+```
 
 Finally, read the response from the Arduino and print it out:
 
-{% highlight Python %}
+```python
 # Read data back from Arduino
 echoLine = ser.readline()
 
 # readline() returns raw bytes; decode to a UTF-8 string and strip whitespace
 print(echoLine.decode('utf-8').strip())
 print() # empty line
-{% endhighlight Python %}
+```
 
 And that's it! This code is available as [serial_demo.py](https://github.com/makeabilitylab/arduino/blob/master/Python/Serial/serial_demo.py) in our GitHub. Note that after creating the `Serial` object, we wrap everything in a `while True:` loop to continuously ask for new user data.
 
 One important detail: if you exit the script with `Ctrl+C` without closing the serial port, the OS may keep the port locked—which means you won't be able to upload new Arduino code or open Serial Monitor until you kill the Python process. To handle this gracefully, wrap your loop in a `try`/`except`/`finally` block:
 
-{% highlight Python %}
+```python
 import serial
 import time
 
@@ -573,7 +573,7 @@ except KeyboardInterrupt:
 finally:
     ser.close()
     print("Serial port closed.")
-{% endhighlight Python %}
+```
 
 The `finally` block ensures `ser.close()` is called whether the loop ends normally or via `Ctrl+C`. This is a good habit for any program that opens hardware resources.
 
@@ -655,7 +655,7 @@ For each, we will be running [DisplayTextSerialIn.ino](https://github.com/makeab
 
 Essentially, [DisplayTextSerialIn.ino](https://github.com/makeabilitylab/arduino/blob/master/Serial/DisplayTextSerialIn/DisplayTextSerialIn.ino) does this:
 
-{% highlight C %}
+```cpp
 // Declaration for an SSD1306 display connected to I2C (SDA, SCL pins)
 #define OLED_RESET     4 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 _display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
@@ -684,4 +684,5 @@ void loop(){
     Serial.print(rcvdSerialData);
     Serial.println("'");
 }
-{% endhighlight C %} -->
+```
+-->

--- a/communication/web-serial.md
+++ b/communication/web-serial.md
@@ -71,10 +71,10 @@ Web Serial is supported by **Chrome** (89+), **Edge** (89+), and **Opera** (76+)
 
 To quickly check whether your browser supports Web Serial, open the developer console (`Ctrl+Shift+I` on Windows/Linux, `Cmd+Option+I` on Mac) and type:
 
-{% highlight JavaScript %}
+```javascript
 > "serial" in navigator
 true
-{% endhighlight JavaScript %}
+```
 
 If the result is `true`, your browser supports Web Serial. If `false`, switch to Chrome.
 
@@ -88,18 +88,18 @@ Here's a quick overview of the key steps:
 
 For security, the browser requires the user to explicitly select and grant permission to a serial port. This is triggered by calling `navigator.serial.requestPort()`:
 
-{% highlight JavaScript %}
+```javascript
 // Prompt user to select any serial port.
 const port = await navigator.serial.requestPort();
-{% endhighlight JavaScript %}
+```
 
 The [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) keyword pauses execution until the user selects a port from the browser's permission dialog.
 
 You can try this yourself! Open the dev console on any page served over HTTPS or localhost and type:
 
-{% highlight JavaScript %}
+```javascript
 > await navigator.serial.requestPort();
-{% endhighlight JavaScript %}
+```
 
 If your Arduino is plugged in, you should see a dialog like this:
 
@@ -111,13 +111,13 @@ If your Arduino is plugged in, you should see a dialog like this:
 
 To open the port, call `port.open()` with a [SerialOptions](https://wicg.github.io/serial/#dom-serialoptions) dictionary. The only required option is `baudRate`:
 
-{% highlight JavaScript %}
+```javascript
 // Prompt user to select a serial port
 const port = await navigator.serial.requestPort();
 
 // Open the port at 9600 baud
 await port.open({ baudRate: 9600 });
-{% endhighlight JavaScript %}
+```
 
 The other options (`dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`) default to the standard 8N1 configuration we discussed in the [previous lesson](serial-intro.md#the-asynchronous-serial-communication-frame). You typically don't need to change them.
 
@@ -125,7 +125,7 @@ The other options (`dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`
 
 To write text data, use a `TextEncoderStream` piped to the port's writable stream:
 
-{% highlight JavaScript %}
+```javascript
 const textEncoder = new TextEncoderStream();
 const writableStreamClosed = textEncoder.readable.pipeTo(port.writable);
 
@@ -134,13 +134,13 @@ await writer.write("hello");
 
 // Release the lock so the port can be closed later
 writer.releaseLock();
-{% endhighlight JavaScript %}
+```
 
 #### Reading data
 
 Reading works similarly, using a `TextDecoderStream` and a read loop:
 
-{% highlight JavaScript %}
+```javascript
 const textDecoder = new TextDecoderStream();
 const readableStreamClosed = port.readable.pipeTo(textDecoder.writable);
 const reader = textDecoder.readable.getReader();
@@ -155,7 +155,7 @@ while (true) {
   // value is a string
   console.log(value);
 }
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > The raw Web Serial API works, but it's verbose—especially for the stream setup, line buffering, and error handling. That's why we built a wrapper library called `serial.js` to simplify things. Let's look at that next!
@@ -166,9 +166,9 @@ To make it easier to work with Web Serial, we wrote a JavaScript library called 
 
 To use it, add this `<script>` tag in the `<head>` or `<body>` of your HTML file:
 
-{% highlight HTML %}
+```html
 <script src="https://cdn.jsdelivr.net/gh/makeabilitylab/js@main/dist/makelab.serial.iife.js"></script>
-{% endhighlight HTML %}
+```
 
 This loads our serial library from the [jsDelivr CDN](https://www.jsdelivr.com/). After loading, the `Serial`, `SerialEvents`, and `SerialState` classes are available as global variables—no `import` statements needed!
 
@@ -182,18 +182,18 @@ This loads our serial library from the [jsDelivr CDN](https://www.jsdelivr.com/)
 
 [`serial.js`](https://github.com/makeabilitylab/js) uses an **event-based architecture** with callback functions, which is a common pattern in web and UI programming (see: Mozilla's [Introduction to Events](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events)). The `Serial` class fires four events:
 
-{% highlight JavaScript %}
+```javascript
 const SerialEvents = Object.freeze({
   CONNECTION_OPENED: "CONNECTION_OPENED",  // Serial port successfully opened
   CONNECTION_CLOSED: "CONNECTION_CLOSED",  // Serial port closed
   DATA_RECEIVED:     "DATA_RECEIVED",      // New line of text received
   ERROR_OCCURRED:    "ERROR_OCCURRED",      // Error during connection or I/O
 });
-{% endhighlight JavaScript %}
+```
 
 To create a `Serial` object and subscribe to events:
 
-{% highlight JavaScript %}
+```javascript
 // Setup Web Serial using serial.js
 const serial = new Serial();
 
@@ -222,7 +222,7 @@ function onSerialDataReceived(eventSender, newData) {
 function onSerialErrorOccurred(eventSender, error) {
   console.log("Serial error:", error);
 }
-{% endhighlight JavaScript %}
+```
 
 You don't need to subscribe to *all* events—just the ones you need. But subscribing to `ERROR_OCCURRED` is helpful for debugging when things go wrong.
 
@@ -230,45 +230,45 @@ You don't need to subscribe to *all* events—just the ones you need. But subscr
 
 The simplest way to open a connection is with `connectAndOpen()`, which prompts the user for a port and opens it in one step:
 
-{% highlight JavaScript %}
+```javascript
 // Prompt user to select a port and open it at 9600 baud (default)
 await serial.connectAndOpen();
 
 // Or specify a baud rate (e.g., for ESP32)
 await serial.connectAndOpen(null, { baudRate: 115200 });
-{% endhighlight JavaScript %}
+```
 
 {: .note }
 > Because `connectAndOpen()` triggers a browser permission dialog, it **must be called from a user gesture** like a button click. You can't call it automatically when the page loads.
 
 There is also `autoConnectAndOpenPreviouslyApprovedPort()`, which reconnects to a port the user has previously approved—without showing the permission dialog again. This is useful for web apps where you don't want to ask the user to re-select their Arduino every time the page reloads:
 
-{% highlight JavaScript %}
+```javascript
 // Automatically reconnect to a previously approved port
 await serial.autoConnectAndOpenPreviouslyApprovedPort({ baudRate: 9600 });
-{% endhighlight JavaScript %}
+```
 
 ### Writing data
 
 To send data to the Arduino, use `writeLine()` (which appends a newline character) or `write()`:
 
-{% highlight JavaScript %}
+```javascript
 // Send "Hello" followed by a newline (\n)
 await serial.writeLine("Hello");
 
 // Send text without a newline
 await serial.write("data");
-{% endhighlight JavaScript %}
+```
 
 ### Checking connection state
 
-{% highlight JavaScript %}
+```javascript
 serial.isOpen();  // returns true or false
 serial.state;     // returns "closed", "opening", "open", or "closing"
 
 // Check browser support (static method)
 Serial.isWebSerialSupported(); // returns true or false
-{% endhighlight JavaScript %}
+```
 
 ## Let's make stuff!
 
@@ -310,7 +310,7 @@ The full experience looks like this:
 
 Create a folder called `SliderOut` with an empty `index.html` file. Open the folder in VSCode (`File → Open Folder`). Start with this minimal HTML:
 
-{% highlight HTML %}
+```html
 <!DOCTYPE html>
 <html>
 <head>
@@ -321,7 +321,7 @@ Create a folder called `SliderOut` with an empty `index.html` file. Open the fol
   Content will go here!
 </body>
 </html>
-{% endhighlight HTML %}
+```
 
 Save (`Ctrl+S`) and launch it with Live Server to verify everything is working. You should see a blank page with "Content will go here!" at `127.0.0.1:5500`.
 
@@ -329,7 +329,7 @@ Save (`Ctrl+S`) and launch it with Live Server to verify everything is working. 
 
 Now let's add our serial library, a heading, and a connect button. Because Web Serial requires explicit user permission, we need a button the user can click to initiate the connection.
 
-{% highlight HTML %}
+```html
 <!DOCTYPE html>
 <html>
 <head>
@@ -382,7 +382,7 @@ Now let's add our serial library, a heading, and a connect button. Because Web S
   </script>
 </body>
 </html>
-{% endhighlight HTML %}
+```
 
 Save, reload, and try clicking the button with your Arduino plugged in. The browser will show a permission dialog listing available serial ports. Select your Arduino and click "Connect." You should see `onSerialConnectionOpened` in the dev console.
 
@@ -394,16 +394,16 @@ Save, reload, and try clicking the button with your Arduino plugged in. The brow
 
 Now let's add a slider to select and send values between 0 and 255. In HTML, sliders are [`<input type="range">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range) elements. Add this below the button:
 
-{% highlight HTML %}
+```html
 <button id="connect-button" onclick="onConnectButtonClick()">Connect via Serial Port</button>
 <label for="slider">LED brightness:</label>
 <input id="slider" type="range" min="0" max="255"
   value="128" onchange="onSliderValueChanged(this, event)" />
-{% endhighlight HTML %}
+```
 
 And add the `onSliderValueChanged()` function to the `<script>` block:
 
-{% highlight JavaScript %}
+```javascript
 async function onSliderValueChanged(src, event) {
   console.log("Writing to serial: ", src.value.toString());
   // Note: we intentionally don't await writeLine() here because we don't
@@ -411,7 +411,7 @@ async function onSliderValueChanged(src, event) {
   // slider change. Awaiting would make the slider feel sluggish.
   serial.writeLine(src.value);
 }
-{% endhighlight JavaScript %}
+```
 
 That's it! Save and try it. Move the slider and watch the LED brightness change on your Arduino:
 
@@ -425,7 +425,7 @@ That's it! Save and try it. Move the slider and watch the LED brightness change 
 
 Let's make a few UI improvements. First, **hide** the connect button after a successful connection and **show** the slider controls only after connecting:
 
-{% highlight HTML %}
+```html
 <button id="connect-button" onclick="onConnectButtonClick()">Connect via Serial Port</button>
 
 <div id="interactive-controls" style="display:none">
@@ -434,11 +434,11 @@ Let's make a few UI improvements. First, **hide** the connect button after a suc
   <input id="slider" type="range" min="0" max="255"
     value="128" onchange="onSliderValueChanged(this, event)" />
 </div>
-{% endhighlight HTML %}
+```
 
 Then update the JavaScript to toggle visibility and display the current slider value:
 
-{% highlight JavaScript %}
+```javascript
 // Initialize slider display on page load
 let sliderVal = document.getElementById('slider').value;
 document.getElementById('slider-value').textContent = sliderVal;
@@ -456,7 +456,7 @@ async function onSliderValueChanged(src, event) {
   // Update the slider value text on the page
   document.getElementById('slider-value').textContent = src.value;
 }
-{% endhighlight JavaScript %}
+```
 
 #### Full slider video demo
 
@@ -486,7 +486,7 @@ For the circuit, we need an Arduino and an [OLED display](../advancedio/oled.md)
 
 Create a new folder called `DisplayText` with an `index.html` file. Start with this HTML:
 
-{% highlight HTML %}
+```html
 <!DOCTYPE html>
 <html>
 <head>
@@ -512,13 +512,13 @@ Create a new folder called `DisplayText` with an `index.html` file. Start with t
   </div>
 </body>
 </html>
-{% endhighlight HTML %}
+```
 
 #### Add the JavaScript
 
 Add a `<script>` block at the end of the `<body>`. This code sets up the serial connection, sends text as the user types, and displays the Arduino's echo response:
 
-{% highlight HTML %}
+```html
 <script>
   const inputText = document.getElementById('input-text');
   const outputText = document.getElementById('output-text');
@@ -576,13 +576,13 @@ Add a `<script>` block at the end of the `<body>`. This code sets up the serial 
     }
   }
 </script>
-{% endhighlight HTML %}
+```
 
 #### Add CSS
 
 Create a `css/styles.css` file to clean up the interface:
 
-{% highlight CSS %}
+```css
 #main-content {
   margin: auto;
   width: 800px;
@@ -597,16 +597,16 @@ input {
 #text-interface {
   display: none;
 }
-{% endhighlight CSS %}
+```
 
 Link it in the `<head>`:
 
-{% highlight HTML %}
+```html
 <head>
   ...
   <link rel="stylesheet" href="css/styles.css">
 </head>
-{% endhighlight HTML %}
+```
 
 That's it! You now have a bidirectional web serial app. Play and experiment!
 

--- a/esp32/esp32-ide.md
+++ b/esp32/esp32-ide.md
@@ -44,7 +44,7 @@ The Arduino IDE doesn't include ESP32 support by default—you need to add Espre
 2. Go to **File → Preferences** (or **Arduino → Settings** on macOS)
 3. In the **Additional Board Manager URLs** field, add:
    
-   ```
+   ```text
    https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
    ```
    {: .fs-1 }
@@ -142,7 +142,7 @@ You could also try to blink the built-in RGB LED that is available on some ESP32
 
 If you see a compilation error like `fork/exec .../ctags: bad CPU type in executable` or similar for `avr-g++`, the Arduino toolchain includes x86-only binaries that can't run natively on Apple Silicon (M1–M4). This affects **all boards**, not just ESP32. Install Apple's Rosetta 2 translation layer by opening Terminal and running:
 
-```
+```bash
 softwareupdate --install-rosetta
 ```
 

--- a/esp32/led-fade.md
+++ b/esp32/led-fade.md
@@ -130,7 +130,7 @@ The [LEDC library](https://docs.espressif.com/projects/arduino-esp32/en/latest/a
 
 If you attempt to set incompatible frequency and resolution combinations, you'll see an error on the Serial Monitor:
 
-```
+```text
 E (196) ledc: requested frequency and duty resolution cannot be achieved,
 try reducing freq_hz or duty_resolution.
 ```

--- a/sensors/photoresistors.md
+++ b/sensors/photoresistors.md
@@ -210,7 +210,7 @@ Either wiring will work. They are functionally equivalent but have opposite beha
 
 And, of course, we could inverse the relationship in software (rather than hardware). So, for example, if we wanted to make an LED brighter as light levels decrease with the left wiring configuration, we could do the following:
 
-{% highlight C %}
+```cpp
 
 // In this code, we brighten an LED inversely proportional to light level (as measured by 
 // a photoresistor). We assume the photoresistor is R1 and fixed resistor is R2 in the 
@@ -220,17 +220,17 @@ int ledVal = map(photoresistorVal, 0, 1023, 0, 255); // convert to 8-bit range (
 ledVal = 255 - ledVal; // invert so that LED gets brighter as photoresistor gets darker
 analogWrite(OUTPUT_LED_PIN, ledVal);
 
-{% endhighlight C %}
+```
 
 And I often like to simplify this even more by relying on `map` for the inversion (notice how I flip the order of `255` and `0`), so the code becomes:
 
-{% highlight C %}
+```cpp
 
 int photoresistorVal = analogRead(INPUT_PHOTORESISTOR_PIN); // read in photoresistor val
 int ledVal = map(photoresistorVal, 0, 1023, 255, 0); // inverse relationship
 analogWrite(OUTPUT_LED_PIN, ledVal);
 
-{% endhighlight C %}
+```
 
 ### What value should we make our fixed resistor?
 

--- a/signals/index.md
+++ b/signals/index.md
@@ -39,7 +39,7 @@ These lessons are intended to be interactive. You should modify, run, iterate, a
 
 There are three ways to view the lessons: **first**, you can click on the exported HTML versions; however, these are not interactive; **second**, you can clone our [Signals repo](https://github.com/makeabilitylab/signals) and open the `ipynb` files locally on your computer (this is our recommended approach):
 
-```
+```bash
 git clone https://github.com/makeabilitylab/signals.git
 ```
 

--- a/signals/jupyter-notebook.md
+++ b/signals/jupyter-notebook.md
@@ -38,7 +38,7 @@ Download and install [Anaconda](https://www.anaconda.com/download) (latest Pytho
 
 Open your terminal (on linux or Mac) or the Anaconda Prompt (on Windows) and type:
 
-```
+```text
 > jupyter notebook
 ```
 
@@ -61,7 +61,7 @@ Feel free to follow the official installation instructions [here](https://jupyte
 
 To install the `nbextensions`, open your terminal (on linux or Mac) or the Anaconda Prompt (on Windows) and type:
 
-```
+```text
 > conda install -c conda-forge jupyter_contrib_nbextensions
 ```
 

--- a/website-dev.md
+++ b/website-dev.md
@@ -20,7 +20,7 @@ usetocbot: true
 ## Running the website
 Assuming you have the prerequisite libraries and software infrastructure (e.g., Jekyll)—see our [website development setup guide here](website-install.md)—you can open terminal in VSCode and type:
 
-```
+```text
 > bundle exec jekyll serve 
 ```
 
@@ -185,27 +185,51 @@ htmlproofer ./_site --disable-external --swap-urls "^/physcomp:" \
 ## Code highlighting
 <!-- Code snippet highlighting: https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting -->
 
-### Using Jekyll's `highlight` functionality
-This is a test.
-{% highlight C %}
-void loop() {
-  digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
-  digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(1000);               // wait for a second
-}
-{% endhighlight C %}
+**Standard:** write code in fenced blocks (triple backticks) with a **required
+language token** on the opening fence. Use `cpp` for **all** Arduino/ESP32
+sketches (our house style), and a real token for everything else — `javascript`,
+`html`, `css`, `json`, `python`, `bash`, etc. For terminal sessions, program
+output, file trees, or other non-source text, use `text` (highlighters render it
+verbatim, and it still satisfies the language requirement).
 
-### Using Markdown's tickmarks
-
-```
+````markdown
+```cpp
 void loop() {
-  digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
-  digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(1000);               // wait for a second
+  digitalWrite(led, HIGH);   // turn the LED on
+  delay(1000);               // wait a second
 }
 ```
+````
+
+Do **not** use Jekyll's `{% raw %}{% highlight %}{% endraw %}` Liquid tags. They
+were fine historically, but the whole site was migrated to fenced blocks (issue
+#99) for portability, tooling, and to de-risk a future framework move where
+Liquid tags would all need rewriting.
+
+**This is enforced in CI.** The `code-blocks` job in
+`.github/workflows/content-lint.yml` runs `markdownlint` with the scoped config
+`.markdownlint-code.jsonc`:
+
+- **MD040** — every fenced block must declare a language token.
+- **MD046** — code must be *fenced*, never indented (an indented block can't
+  carry a language, so it would silently dodge MD040). For a deliberate indented
+  demo, opt out inline with `<!-- markdownlint-disable MD046 -->` … `<!-- markdownlint-enable MD046 -->`.
+- **MD048** — fences use backticks (` ``` `), not tildes.
+
+The config is intentionally separate from the editor's `.markdownlint.jsonc` so
+the gate only checks these three rules (not the many unrelated style nits the
+older content predates). Run it locally with:
+
+```bash
+npx markdownlint-cli@0.48.0 -c .markdownlint-code.jsonc "**/*.md" --ignore "_site" --ignore "node_modules"
+```
+
+**Liquid inside a code block.** Fenced blocks do *not* stop Jekyll from
+executing Liquid, so if a block must *show* literal Liquid (e.g. an
+`if page.usemathjax` conditional), wrap it in `raw`/`endraw` tags and Jekyll
+prints it verbatim instead of running it — see the
+[Adding LaTeX support](#adding-latex-support) example below, which does exactly
+this.
 
 ### Using `gist-it.appspot.com` to embed code directly from GitHub
 <!-- <script src="http://gist-it.appspot.com/http://github.com/$file"></script> -->
@@ -264,12 +288,17 @@ It works with almost all markdown flavours (the below blank line matters). This 
 ### Option 3: Use tabs
 This version is using tabs:
 
+<!-- markdownlint-disable MD046 -->
+<!-- Intentionally indented: this block demonstrates the tab/indent code-block syntax itself. -->
+
     Start on a fresh line
     Hit tab twice, type up the content
     Your content should appear in a box. However, doesn't appear to now support markdown. For example, **this** should be bold. However, I can still use html it appears? For example, <b>this</b> is bold? Or maybe not! So, perhaps this is treated as a code block or something...
 
+<!-- markdownlint-enable MD046 -->
+
 This version is using tick marks (rather than tabs) but it should render in the same way:
-```
+```text
 Use tickmarks
 ```
 
@@ -301,7 +330,7 @@ This paragraph is now using the `.test-css` style. We do this by using this synt
 
 So, the markdown looks like this:
 
-```
+```markdown
 This paragraph is now using the `.test-css` style. We do this by using this syntax `{: .test-css}` below the element we want styled.
 {: .test-css}
 ```
@@ -314,13 +343,15 @@ After a bit of experimentation, I got LaTeX to work using a **remote** Jekyll te
 2. Since I'm currently using `remote_theme: pmarsceill/just-the-docs`, I was a bit confused about how to make local configuration changes since most online blogs, forum posts talk about editing content in the `_includes` folder; however, I didn't have this in my local dev environment. So, what to do?
 3. I manually made a `_includes` folder with the filename `head_custom.html` and put in there:
 
-{% highlight html %}{% raw %}
+{% raw %}
+```html
 {% if page.usemathjax %}
 <script type="text/javascript" async
  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 </script>
 {% endif %}
-{% endraw %}{% endhighlight %}
+```
+{% endraw %}
 
 ### Using LaTeX on markdown pages
 On pages where you want to use LaTeX, then add `usemathjax: true` to the header content
@@ -335,20 +366,20 @@ Because I'm forever a LaTeX n00b, I found this online [WYSIWYG LaTeX math editor
 
 I tried to get Disqus working with Jekyll by following their official instructions; however, it *just* wouldn't work and I didn't have significant time to try and troubleshoot/debug. I kept getting the non-help error printed out in Chrome's dev tool console:
 
-```
+```text
 Uncaught SyntaxError: Unexpected end of input   led-on.html:1
 ```
 
 And in FireFox:
 
-```
+```text
 SyntaxError: missing } after function body led-on.html:1:754
 note: { opened at line 1, column 287  led-on.html:1:287
 ```
 
 But I thought I'd try once more and I came across a [blog posting](https://disqus.com/home/discussion/channel-discussdisqus/why_does_the_disqus_not_work_in_jekyll/) that had the solution The "Universal Code" that Disqus has you embed on your website includes `// single line` comments and `/* multi-line */` comments. However, when Jekyll builds the website, it places the entire produced html on one line (read: not beautified), so the single-line comments disrupt the code. Here's the code that **doesn't work**.
 
-{% highlight HTML %}
+```html
 <div id="disqus_thread"></div>
 <script>
     /**
@@ -373,11 +404,11 @@ But I thought I'd try once more and I came across a [blog posting](https://disqu
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by
         Disqus.</a></noscript>
 </div>
-{% endhighlight HTML %}
+```
 
 And here's the code that **does** work with the single line comments replaced with multi-line comments:
 
-{% highlight HTML %}
+```html
 <div id="disqus_thread"></div>
 <script>
     /**
@@ -402,7 +433,7 @@ And here's the code that **does** work with the single line comments replaced wi
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by
         Disqus.</a></noscript>
 </div>
-{% endhighlight HTML %}
+```
 
 ## Troubleshooting video playback locally
 
@@ -410,8 +441,10 @@ Jekyll's built-in WEBrick server doesn't support HTTP range requests,
 which browsers need to stream `<video>` elements. If videos fail to 
 load or play, try serving the built site with a different local server:
 
-    bundle exec jekyll build
-    python3 -m http.server 4000 --directory _site
+```bash
+bundle exec jekyll build
+python3 -m http.server 4000 --directory _site
+```
 
 Alternatively, `npx serve _site` works well. Both support range 
 requests and handle large media files reliably.
@@ -419,7 +452,9 @@ requests and handle large media files reliably.
 If videos are still slow, check file sizes. Compress large `.mp4` 
 files with ffmpeg:
 
-    ffmpeg -i input.mp4 -crf 28 -preset fast -movflags +faststart output.mp4
+```bash
+ffmpeg -i input.mp4 -crf 28 -preset fast -movflags +faststart output.mp4
+```
 
 The `-movflags +faststart` flag moves metadata to the front of the 
 file so browsers can begin playback before the full download completes.

--- a/website-install.md
+++ b/website-install.md
@@ -40,7 +40,7 @@ Below, we will walk you through dev environment setup on both Mac and Windows.
 
 Regardless of which platform you're using, the first step is to clone the [physcomp repo](https://github.com/makeabilitylab/physcomp). Open your command prompt and run:
 
-```
+```text
 > git clone https://github.com/makeabilitylab/physcomp.git
 ```
 
@@ -60,7 +60,7 @@ Follow the installation guide closely. I did each step except for I skipped the 
 
 Once Ruby is installed, run:
 
-```
+```text
 > gem install jekyll
 ```
 
@@ -72,7 +72,7 @@ As of Jekyll 4.4+, this also installs `webrick` automatically, so you do **not**
 
 Change into the `physcomp` directory and run `bundle install`:
 
-```
+```text
 > cd physcomp
 > bundle install
 ```
@@ -82,7 +82,7 @@ Note: I typically do this from within VSCode's Terminal.
 #### Run 'bundle exec jekyll serve' in physcomp dir
 Finally, from within the `physcomp` folder, type:
 
-```
+```text
 > bundle exec jekyll serve
 ```
 
@@ -94,14 +94,14 @@ And that's it! Hopefully the server will be running at [http://127.0.0.1:4000/ph
 
 If you see an error like the following when running `bundle exec jekyll serve`:
 
-```
+```text
 /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve/servlet.rb:3:in
   `require': cannot load such file -- webrick (LoadError)
 ```
 
 This means webrick isn't in your bundle. Fix it by running (from inside `physcomp`!):
 
-```
+```text
 > bundle add webrick
 > bundle exec jekyll serve
 ```
@@ -110,7 +110,7 @@ This was required for Ruby 3.0+ with older versions of Jekyll. With Jekyll 4.4+,
 
 **"Could not locate Gemfile" error**
 
-```
+```text
 Could not locate Gemfile
 ```
 
@@ -120,7 +120,7 @@ This means you ran a `bundle` command from the wrong directory. Make sure you `c
 
 If the remote theme (just-the-docs) isn't updating, try stopping the server (Ctrl-C) and running with `--incremental` disabled:
 
-```
+```text
 > bundle exec jekyll serve --no-incremental
 ```
 
@@ -155,7 +155,7 @@ When the Ruby Installer finishes, it just disappears. So, on to the next step!
 #### Run 'gem install jekyll'
 **Second**, I then opened `Windows Powershell` and typed `gem install jekyll`:
 
-```
+```text
 gem install jekyll
 Fetching jekyll-4.1.1.gem
 Fetching mercenary-0.4.0.gem
@@ -178,7 +178,7 @@ Here's a screenshot:
 #### Run 'gem install github-pages'
 **Third**, I then tried to install `github-pages` via: `gem install github-pages`. So, run:
 
-```
+```text
 > gem install github-pages
 ```
 
@@ -189,7 +189,7 @@ This worked well on some of our Windows systems but others failed. If this succe
 
 When running `gem install github-pages`, you may encounter an error about Nokogiri versions:
 
-```
+```text
 ERROR:  Error installing github-pages:
         The last version of nokogiri (>= 1.10.4, < 2.0) to support your Ruby & RubyGems was 1.10.9. Try installing it with `gem install nokogiri -v 1.10.9` and then running the current command again
         nokogiri requires Ruby version >= 2.3, < 2.7.dev. The current ruby version is 2.7.0.0.
@@ -197,7 +197,7 @@ ERROR:  Error installing github-pages:
 
 So, I tried:
 
-```
+```text
 > gem install nokogiri -v 1.10.9
 ERROR:  Error installing nokogiri:
         The last version of nokogiri (= 1.10.9) to support your Ruby & RubyGems was 1.10.9. Try installing it with `gem install nokogiri -v 1.10.9`
@@ -206,7 +206,7 @@ ERROR:  Error installing nokogiri:
 
 But this also failed. And given that I have no idea how hard it would be to downgrade Ruby and whether that would wreck other dependences, I searched the Internet and found this [Issue](https://github.com/sparklemotion/nokogiri/issues/1961) on the Nokogiri GitHub. So, then I tried [this](https://github.com/sparklemotion/nokogiri/issues/1961#issuecomment-581851368):
 
-```
+```text
 > gem inst nokogiri --pre
 Fetching nokogiri-1.11.0.rc2-x64-mingw32.gem
 Nokogiri is built with the packaged libraries: libxml2-2.9.10, libxslt-1.1.34, zlib-1.2.11, libiconv-1.15.
@@ -221,7 +221,7 @@ This worked. Yay!
 
 But I still couldn't install github pages, boo!
 
-```
+```text
 gem install github-pages
 ERROR:  Error installing github-pages:
         The last version of nokogiri (>= 1.10.4, < 2.0) to support your Ruby & RubyGems was 1.10.9. Try installing it with `gem install nokogiri -v 1.10.9` and then running the current command again
@@ -241,13 +241,13 @@ So, then I just skipped to the final step and ran `bundle install` and things wo
 
 From the shell, change directories to `physcomp`. On my machine:
 
-```
+```text
 > cd c:\git\physcomp
 ```
 
 And then run `bundle install`:
 
-```
+```text
 C:\git\physcomp> bundle install
 Fetching gem metadata from https://rubygems.org/...........
 Fetching gem metadata from https://rubygems.org/.
@@ -270,7 +270,7 @@ You've done it!
 
 Assuming you have the prerequisite libraries and software infrastructure (e.g., Jekyll), you can open terminal in VSCode and type:
 
-```
+```text
 > bundle exec jekyll serve 
 ```
 
@@ -282,7 +282,7 @@ If you receive an error like the following, you may need to *restart* your compu
 
 ![](assets/images/BundleExecJekyllServeFailsInVSCodeScreenshot.png)
 
-```
+```text
 Try the new cross-platform PowerShell https://aka.ms/pscore6
 
 PS D:\Git\physcomp> bundle exec jekyll serve 


### PR DESCRIPTION
Closes #99.

## What

Migrates the whole textbook from Jekyll `{% highlight %}` Liquid tags to fenced code blocks with a **required language token**, and adds a CI gate so the convention stays enforced.

### Content (35 pages)
- All `{% highlight LANG %}`…`{% endhighlight %}` → fenced ` ```lang ` blocks. Language tokens normalized to lowercase; **`cpp` for all Arduino/ESP32 sketches** (was `C`/`C++`); `JavaScript`→`javascript`, `HTML`→`html`, `CSS`→`css`, etc.
- Every previously-bare ` ``` ` block gets a language: `text` for terminal/program output, file trees, and format examples; `bash` for shell commands. (Satisfies MD040 site-wide.)
- Fixed two commented-out example blocks whose opener migrated but whose inline closer didn't, which left unbalanced Liquid tags. The LaTeX doc example is now correctly wrapped in `raw`/`endraw` so it renders literally.

### Gate
- **`.markdownlint-code.jsonc`** — a scoped config (MD040 language-required, MD046 fenced-not-indented, MD048 backtick fences), intentionally **separate** from the editor `.markdownlint.jsonc` so the gate only checks code-block rules (not the many unrelated style nits the older content predates).
- New **`code-blocks`** job in `content-lint.yml` running `markdownlint-cli -c` (which *replaces* config; cli2 merges the editor config back in).
- Convention documented in `website-dev.md` "Code highlighting"; deliberate indented demos opt out with `<!-- markdownlint-disable MD046 -->`.

## Why
Portability + tooling, and de-risking a future framework migration (#103) where Liquid tags would all need rewriting. `{% highlight %}` was legitimate when the site started — this is a forward move, not a fix.

## Verification
- `bundle exec jekyll build` — clean (Jekyll 4).
- Scoped gate green across the repo (`markdownlint-cli@0.48.0 -c .markdownlint-code.jsonc`).
- Spot-checked rendered HTML: 35 files with Rouge-highlighted `cpp` blocks; commented blocks stay hidden; literal Liquid in the LaTeX example renders verbatim; no leaked tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)