### PR TITLE
Roll out hero media to lessons (pilot + cross-module)

### DIFF
--- a/arduino/arduino-ide.md
+++ b/arduino/arduino-ide.md
@@ -19,6 +19,10 @@ usetocbot: true
 {:toc}
 ---
 
+![Screenshot of the Arduino IDE with an empty sketch showing setup() and loop() functions](assets/images/ArduinoIDE_BlankAndAnnotated.png)
+**Figure.** Coming up: by the end of this lesson, you'll have the Arduino IDE installed and configured, with a new sketch open showing the `setup()` and `loop()` functions ready to program your board.
+{: .fs-1 }
+
 The Arduino IDE (Integrated Development Environment) is where you'll write, compile, and upload code to your Arduino board. This page walks through downloading, installing, and configuring the IDE so you're ready to start programming.
 
 ## Download and install the Arduino IDE

--- a/arduino/rgb-led-fade.md
+++ b/arduino/rgb-led-fade.md
@@ -21,6 +21,12 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/zL7xIWHqVaY" title="Workbench video of an RGB LED smoothly crossfading through the color wheel on an Arduino Uno" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** Where we're headed: an RGB LED smoothly crossfading through the color wheel, driven by `analogWrite()` and the HSL color space on an Arduino Uno.
+{: .fs-1 }
+
 In this lesson, you will learn how to fade between RGB colors using [`analogWrite`](https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/), how to use the [HSL colorspace](https://en.wikipedia.org/wiki/HSL_and_HSV) to more easily (and independently) control hue and brightness, and how to use and load local `C/C++` libraries.
 
 ---

--- a/arduino/tone.md
+++ b/arduino/tone.md
@@ -21,7 +21,11 @@ usetocbot: true
 {:toc}
 ---
 
-<!-- TODO: Record a video of a melody playing on a piezo buzzer (with an LED flashing in sync) and embed here as the opening hook -->
+<video controls playsinline aria-label="Star Wars Imperial March playing on an Arduino Leonardo with the built-in LED flashing in sync">
+  <source src="assets/videos/Arduino_Tone-PlayImperialMarch_Handheld_web.mp4" type="video/mp4" />
+</video>
+**Video.** A preview of what we'll build: the Imperial March from Star Wars played on a piezo buzzer with the `tone()` function, with the built-in LED flashing in time with each note.
+{: .fs-1 }
 
 So far, every output we've produced has been visual—turning LEDs on, off, fading, and blinking. In this lesson, we'll add a completely new output modality: **sound!** Using a piezo buzzer and the Arduino [`tone()`](https://www.arduino.cc/reference/en/language/functions/advanced-io/tone/) function, we'll learn how to play individual notes, scales, and even melodies.
 

--- a/communication/p5js-serial-io.md
+++ b/communication/p5js-serial-io.md
@@ -20,6 +20,12 @@ usetocbot: true
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Video demonstrating the full DisplayShapeBidirectional demo with p5.js buttons and Arduino buttons controlling shapes">
+  <source src="assets/videos/DisplayShapeBidirectional_TrimmedAndOptimized900w.mp4" type="video/mp4" />
+</video>
+**Video.** A preview of what we'll build: **DisplayShapeBidirectional**, where p5.js buttons *and* physical Arduino buttons control a shape shared between the browser canvas and the OLED display. ([live page](http://makeabilitylab.github.io/p5js/WebSerial/p5js/DisplayShapeBidirectional), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/DisplayShapeBidirectional))
+{: .fs-1 }
+
 OK, now we're really rolling! We learned about [serial communication](serial-intro.md), then how to use serial in our browsers ([Web Serial!](web-serial.md)), and then how to do this with [p5.js](p5js-serial.md). And we've already made some cool proof-of-concept demos.
 
 Let's take this growing knowledge and momentum to create slightly more sophisticated programs. First, we'll cover the case of using p5.js to control something on our Arduino (`Computer → Arduino`). Then we'll introduce bidirectional communication (`Computer ↔ Arduino`) where the computer and Arduino work together to create a holistic interactive experience. 🎮

--- a/communication/p5js-serial.md
+++ b/communication/p5js-serial.md
@@ -20,6 +20,12 @@ usetocbot: true
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Video demonstrating the GraphIn p5.js app with a potentiometer showing real-time sensor data as colored bars">
+  <source src="assets/videos/AnalogOut.ino-GraphIn-POT-Trimmed-Optimized.mp4" type="video/mp4" />
+</video>
+**Video.** Where we're headed: **GraphIn**, a p5.js sketch that graphs live Arduino sensor data in the browser in real time (here, from a potentiometer). ([live page](https://makeabilitylab.github.io/p5js/WebSerial/p5js/GraphIn/), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/p5js/GraphIn))
+{: .fs-1 }
+
 We've only started to scratch the surface of what's possible when combining Arduino with computers. In this lesson (and the next), we're going to use a creative coding tool called [p5.js](https://p5js.org/) to help demonstrate this potential. It should be fun! 🎨
 
 {: .note }

--- a/communication/serial-intro.md
+++ b/communication/serial-intro.md
@@ -20,6 +20,12 @@ usetocbot: true
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Video demonstrating the Arduino IDE Serial Monitor sending numeric text to the Arduino, which receives it, displays it on an OLED, and echoes it back.">
+  <source src="assets/videos/SimpleSerialIn-NoTalking-TrimmedAndSpedUp720p.mp4" type="video/mp4" />
+</video>
+**Video.** Serial communication in action—the focus of this lesson: text typed into the Arduino IDE [Serial Monitor](../arduino/serial-print.md) is sent to an Arduino, shown on an [OLED](../advancedio/oled.md), and echoed back.
+{: .fs-1 }
+
 Devices need to communicate. Sensors talk to microcontrollers. Microcontrollers talk to computers. Computers talk to the Internet. And beyond! Many different protocols have been created to support device-to-device communication—from [Ethernet](https://en.wikipedia.org/wiki/Ethernet) and [Zigbee](https://en.wikipedia.org/wiki/Zigbee) to WiFi and Bluetooth. In this lesson, we will focus on **asynchronous serial communication**, specifically TTL serial (Transistor-Transistor Logic Serial)—an enduring standard that has prevailed since the beginning of personal computers and is what the [Arduino Serial library](https://www.arduino.cc/reference/en/language/functions/communication/serial/) uses.
 
 Unlike other popular serial communication protocols like [I<sup>2</sup>C](https://learn.sparkfun.com/tutorials/i2c/all) and [SPI](https://learn.sparkfun.com/tutorials/serial-peripheral-interface-spi/all), TTL serial is *asynchronous*, which means it does not rely on a shared clock signal (precisely timed voltage pulses) paired with its data lines. This has the benefit of fewer wires but does result in a bit of communication overhead for each transmitted "packet" or data frame.

--- a/communication/web-serial.md
+++ b/communication/web-serial.md
@@ -20,6 +20,12 @@ usetocbot: true
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Video demonstrating the full SliderOut demo with a polished interface controlling an LED via Web Serial">
+  <source src="assets/videos/SimpleSerialIn-JavaScript-SliderOut-TrimmedAndSpedUp720p.mp4" type="video/mp4" />
+</video>
+**Video.** By the end of this lesson, you'll build apps like **SliderOut**—dimming an Arduino's LED from a browser slider, straight over USB via the Web Serial API. ([live page](https://makeabilitylab.github.io/p5js/WebSerial/Basic/SliderOut), [code](https://github.com/makeabilitylab/p5js/tree/main/WebSerial/Basic/SliderOut))
+{: .fs-1 }
+
 In our [previous lesson](serial-intro.md), we learned about asynchronous serial communication, Arduino's [Serial library](https://www.arduino.cc/reference/en/language/functions/communication/serial/), and how to write programs—using [Serial Monitor](../arduino/serial-print.md), the command line, and [Python](https://www.python.org/)—to send data to an Arduino.
 
 In this lesson, we'll apply that knowledge to a new and exciting context: **the web browser!** Using the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API), we'll build simple web apps that communicate directly with an Arduino over USB—no drivers, no native installs, just HTML, JavaScript, and a serial cable. 🌐

--- a/cpx/analog-input.md
+++ b/cpx/analog-input.md
@@ -19,15 +19,17 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/S6X4Y5gfekc?si=RysXDQ5unRU7n79H" title="Overview of analog input on the Circuit Playground Express" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** In this lesson, we'll connect *external* analog sensors to the CPX—potentiometers, FSRs, flex sensors, and even a lo-fi slide potentiometer made from paper and a pencil.
+{: .fs-1 }
+
 In Lesson 8, we move beyond working with internal sensors on the CPX (light 💡, microphone 🔊, accelerometer 🍎) and show how to connect external sensors using **analog input**.
 
 ## Lesson 8.1: Overview of Analog Input
 
 In this lesson, we introduce **analog input** on the Circuit Playground Express (CPX) primarily focusing on variable resistive sensors like rotary potentiometers, slide potentiometers, force-sensitive resistors (FSRs), flex sensors (Nintendo Power Glove!), softpot position sensors, and more!
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/S6X4Y5gfekc?si=RysXDQ5unRU7n79H" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
 
 ### Code
 

--- a/cpx/button-piano.md
+++ b/cpx/button-piano.md
@@ -19,6 +19,12 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/wCSWP6PhNvY" title="Building a button piano on the Circuit Playground Express in MakeCode" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** A preview of what we'll build: a Button Piano in MakeCode that plays tones and lights NeoPixels from the CPX's built-in A and B buttons. [Full code](https://makecode.com/_EyqF3g3xb6Cy).
+{: .fs-1 }
+
 In this lesson, we will make our first interactive CPX program in MakeCode—a simple Button Piano—which makes sounds when we press the CPX's built-in buttons.
 
 <!-- Notes to self on lesson:
@@ -26,15 +32,6 @@ In this lesson, we will make our first interactive CPX program in MakeCode—a s
 * Show how MakeCode supports four different button events: click, up, down, etc.
 * If you have a block that doesn't have a notch up top, it means it will run an event when -->
 <!-- Ref: https://youtu.be/NIKu0-Tgh2M (MakeCode Tutorial) -->
-
-## Video Tutorial
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/wCSWP6PhNvY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
-
-**Video.** Creating a button piano. Here's [the full code](https://makecode.com/_EyqF3g3xb6Cy) and a [link to the video on YouTube](https://youtu.be/wCSWP6PhNvY).
-{: .fs-1 }
 
 ## Code
 

--- a/cpx/capacitive-touch.md
+++ b/cpx/capacitive-touch.md
@@ -19,15 +19,17 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/HKwtXrTdocE" title="Introduction to capacitive touch sensing on the Circuit Playground Express" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** In this lesson, we'll explore capacitive touch sensing on the CPX—building a touch "piano," visualizing raw capacitance and touch-threshold values, and calibrating touch sensitivity.
+{: .fs-1 }
+
 In Lesson 5 in our CPX series, we will learn how to use capacitive touch sensing. This is a multi-part series starting with an introduction to capacitive sensing.
 
 ## Lesson 5.1: Intro to Capacitive Touch on the CPX
 
 In this lesson, we will first introduce the concept of capacitive sensing before building a simple capacitive touch "piano." We will then show how to visualize the raw capacitance values and capacitance touch threshold values, which are used to trigger capacitance events. Third, we cover how to use both auto-calibration and manual calibration to change the capacitance touch threshold before building a capacitive-responsive instrument (similar to [Lesson 4: Light-Responsive Instrument](sensor-instrument.md)). 
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/HKwtXrTdocE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
 
 ### Lesson 5.1 Code
 

--- a/cpx/cpx-keyboard.md
+++ b/cpx/cpx-keyboard.md
@@ -19,6 +19,12 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/2ehFfhHLcNQ" title="Using the Circuit Playground Express as a programmable USB keyboard in MakeCode" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** Coming up: the CPX as a programmable USB keyboard built in MakeCode—from simple A and B button presses to a media-controller keyboard and even an accelerometer keyboard.
+{: .fs-1 }
+
 In Lesson 6 of our CPX series, we will learn how to use the CPX as a programmable keyboard. We'll begin by making the A and B buttons into keyboard presses and then create increasingly fun and interesting keyboards, including a media controller keyboard (Lesson 6.2) and an accelerometer-based keyboard (Lesson 6.3).
 
 {: .note }
@@ -27,10 +33,6 @@ Note: there is some overlapping content with [Lesson 5.3: Making a Capacitive Ke
 ## Lesson 6.1: Making a Programmable Keyboard
 
 In this lesson, we will show how to use the CPX as a programmable keyboard
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/2ehFfhHLcNQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
 
 ### Lesson 6.1 Code
 

--- a/cpx/cpx-mouse.md
+++ b/cpx/cpx-mouse.md
@@ -19,15 +19,17 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/bOm1qXTDi-o" title="Using the Circuit Playground Express as a programmable USB mouse in MakeCode" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** The CPX working as a USB mouse, which we'll build in this lesson—first nudging the cursor with the A and B buttons, then steering it continuously by tilting the board.
+{: .fs-1 }
+
 In Lesson 7 of our CPX series, we will learn how to use the CPX as a programmable mouse. We'll begin by making a discrete mouse that shifts the mouse cursor by small amounts with button A and B presses before building a more complex accelerometer-based mouse with continuous input.
 
 ## Lesson 7.1: Making a Programmable Mouse
 
 In this lesson, we will show how to use the CPX as a programmable mouse.
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/bOm1qXTDi-o" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
 
 ### Lesson 7.1 Code
 

--- a/cpx/digital-input.md
+++ b/cpx/digital-input.md
@@ -19,15 +19,17 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/raIc-EuHfmc?si=-KCgO3ypF9kPKBVd" title="Overview of digital input on the Circuit Playground Express" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** By the end of this lesson, you'll wire external buttons to the CPX—and understand the floating-pin problem and how pull-up and pull-down resistors solve it.
+{: .fs-1 }
+
 In Lesson 9, we continue exploring how to hook up and use external electronics with our CPX. In Lesson 8, we worked with analog input—which converts voltage signals from 0 - 3.3V to 0 - 1023. In Lesson 9, we'll work with **digital input**, which converts voltage input signals to either ON (1) or OFF (0). This is useful for components like buttons.
 
 ## Lesson 8.1: Overview of Digital Input
 
 In this lesson, we learn about _what_ is **digital input** and _how_ to use it on the Circuit Playground Express (CPX). We begin similarly to our [analog input lessons](analog-input.md): introducing the 3.3V, GND, and A1 CPX connection pads and showing how the **digital read** function responds to different input voltages (e.g., 3.3V, GND).
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/raIc-EuHfmc?si=-KCgO3ypF9kPKBVd" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
 
 ## Lesson 8.2: Hooking up Buttons to the CPX & Why Pull-down Resistors?
 

--- a/cpx/makecode.md
+++ b/cpx/makecode.md
@@ -19,15 +19,15 @@ usetocbot: true
 {:toc}
 ---
 
-In this lesson, we will make our first MakeCode+CPX program—called Blinky—which will play a sound effect at the start and then repeatedly flash lights. As we build, we will learn about the MakeCode programming environment, the simulator, and how to load our program on to the CPX.
-
-## The MakeCode Programming Environment
-
 <video aria-label="Rapidly building a simple rainbow NeoPixel animation program by dragging blocks in MakeCode" autoplay loop muted playsinline>
   <source src="assets/videos/Making_SimpleFastAnimationProgram_MakeCode_ScreenRecording.mp4" type="video/mp4" />
 </video>
-**Video.** Rapidly creating a full program with MakeCode: a simple rainbow animation. [Code link](https://makecode.com/_8uY3D8Fc8A5t).
+**Video.** A taste of MakeCode—the block editor we'll use all lesson—here building a quick rainbow NeoPixel animation just by dragging blocks. [Code link](https://makecode.com/_8uY3D8Fc8A5t).
 {: .fs-1 }
+
+In this lesson, we will make our first MakeCode+CPX program—called Blinky—which will play a sound effect at the start and then repeatedly flash lights. As we build, we will learn about the MakeCode programming environment, the simulator, and how to load our program on to the CPX.
+
+## The MakeCode Programming Environment
 
 MakeCode is a visual programming language—like [Scratch](https://scratch.mit.edu/)—built on [Blockly](https://developers.google.com/blockly). As the video above shows, to program the CPX, you simply drag-and-drop "puzzle pieces." We call these pieces *blocks.* As you fit blocks together, you can create interactive programs!
 

--- a/cpx/sensor-instrument.md
+++ b/cpx/sensor-instrument.md
@@ -19,18 +19,15 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/RlEPQqyQGEk" title="Building a light-level instrument on the Circuit Playground Express in MakeCode" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** Where we're headed: a light-level instrument that turns light readings into sound and color using the CPX's onboard light sensor, speaker, and NeoPixels. [Full code](https://makecode.com/_drYKXH5UeV1r).
+{: .fs-1 }
+
 In this lesson, we will build on our last lesson—the [Button Piano](button-piano.md)—to make an interactive instrument that translates light levels into sound and light. It won't sound great but it will sound fun!
 
 <!-- TODO consider adding in a lil video of a theremin? -->
-
-## Video Tutorial
-
-<div class="iframe-container">
-  <iframe width="100%" src="https://www.youtube.com/embed/RlEPQqyQGEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
-
-**Video.** Creating a light sensor instrument. Here's [the full code](https://makecode.com/_drYKXH5UeV1r) and a [link to the video on YouTube](https://youtu.be/RlEPQqyQGEk).
-{: .fs-1 }
 
 ## Code
 

--- a/electronics/electricity-basics.md
+++ b/electronics/electricity-basics.md
@@ -20,6 +20,12 @@ usetocbot: true
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Animation of a water tank analogy for electrical circuits. As the water level rises, more water flows out of a hole at the bottom, illustrating how higher voltage produces more current.">
+  <source src="assets/videos/WaterCircuitAnalogy_Trimmed_ByJonFroehlich.mp4" type="video/mp4" />
+</video>
+**Video.** Where we're headed: this lesson uses intuitive water analogies—like this water tank, where a higher water level (voltage) pushes more water (current) out the bottom—to build up the three foundational concepts of voltage, current, and resistance.
+{: .fs-1 }
+
 In this lesson, we are going to learn about three key electricity concepts, **current**, **voltage**, and **resistance**, which form the foundation of electronics and circuits. We will also use an online circuit simulator to play with basic components and advance understanding.
 
 But first—what is a circuit? A **circuit** is a closed loop that provides a path for electric current to flow. At minimum, a circuit requires a voltage source (*e.g.,* a battery), a conductive path (*e.g.,* wires), and a load (*e.g.,* a light bulb or resistor) that does useful work. If the loop is broken at any point, current cannot flow and we call it an "open circuit" (more on this [later](#what-is-an-open-circuit)).

--- a/electronics/ohms-law.md
+++ b/electronics/ohms-law.md
@@ -20,6 +20,10 @@ usetocbot: true
 {:toc}
 ---
 
+![An image showing that for laminar (smooth) flow of water in pipes, the equation for determining the water flow rate (called Poiseuille's Law) is an equivalent to determining the current flow in a circuit using Ohm's Law.](assets/images/PoseuillesLawAndOhmsLaw_FigureByJonFroehlich.png)
+**Figure.** Coming up: Ohm's Law ($$I = \frac{V}{R}$$) ties voltage, current, and resistance together—and, as we'll see, it's the electrical twin of Poiseuille's Law for water flowing through a pipe.
+{: .fs-1 }
+
 In this lesson, we will learn about **Ohm's Law**, one of the most important empirical laws in electrical circuits that describes how *current*, *voltage*, and *resistance* relate together. While Ohm's Law is incredibly useful in analyzing and understanding how circuits work, like many "laws", it is not always obeyed (particularly for what are called "non-ohmic" devices like LEDs or other diodes—which we will explore in [Lesson 6: LEDs](leds.md)).
 
 For now, on to Georg Ohm's Law!

--- a/electronics/schematics.md
+++ b/electronics/schematics.md
@@ -20,6 +20,10 @@ usetocbot: true
 {:toc}
 ---
 
+![A reference chart of common electronic symbols including voltage source, current source, battery, resistive lamp, resistor, switch, diode, and LED. Each symbol is labeled with its name.](assets/images/BasicElectronicSymbols_ByJonFroehlich.png)
+**Figure.** A preview of what we'll build: by the end of this lesson, you'll be able to read and draw circuit schematics using standardized component symbols like these—the visual language of electronics.
+{: .fs-1 }
+
 Before going any further, it's useful to introduce [**circuit schematics**](https://en.wikipedia.org/wiki/Circuit_diagram), which are diagrammatic abstractions of circuits—this will allow us to "speak" about and describe circuits **visually**.
 
 Unlike the more realistic pictorials that we have used thus far (*e.g.,* like [this](assets/videos/ElectronFlowVsConventionalCurrent_PhetSimulation_ByJonFroehlich.mp4) or [this](assets/videos/WaterCircuitAnalogy_Trimmed_ByJonFroehlich.mp4)), circuit schematics are the [*lingua franca*](https://learning.oreilly.com/library/view/practical-electronics-components/9781449373221/app02.html) of electronics—they are compact, standardized, visual representations of circuits. You'll find them in electronic datasheets, CAD layout software, and circuit analysis.

--- a/esp32/iot.md
+++ b/esp32/iot.md
@@ -19,6 +19,12 @@ nav_order: 7
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/DgCFUHGSKSM" title="ESP32 IoT demo: photoresistor data uploading to Adafruit IO dashboard in real time" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** A preview of what we'll build: an ESP32 reading a photoresistor and streaming the light level to an Adafruit IO dashboard that updates live over WiFi. Make sure your sound is on.
+{: .fs-1 }
+
 {: .warning }
 > This lesson is in draft form. There is missing circuit diagrams, images, videos, and other content.
 

--- a/esp32/led-blink.md
+++ b/esp32/led-blink.md
@@ -20,6 +20,12 @@ nav_order: 2
 {:toc}
 ---
 
+<video autoplay loop muted playsinline aria-label="Workbench video showing the Adafruit ESP32-S3 blinking the internal LED on GPIO 13">
+  <source src="assets/videos/ESP32-S3-BlinkyBuiltInLED-IMG_9348-Trimmed_optimized_muted.mp4" type="video/mp4">
+</video>
+**Video.** By the end of this lesson, you'll have your ESP32 blinking on its own—starting with the onboard red LED shown here, then an external LED, the Wokwi simulator, and the colorful onboard NeoPixel.
+{: .fs-1 }
+
 In this lesson, we'll write our first ESP32 program: blinking an LED! If you've completed the Arduino [Blink lesson](../arduino/led-blink.md), you'll find that the code is *identical*—the beauty of the Arduino ecosystem. The challenge here is getting comfortable with the new board's pin layout and the 3.3V operating voltage.
 
 We'll start with the **onboard LED** (no wiring required!), then move to an **external LED circuit**, try it in the **Wokwi simulator**, and finish with a fun bonus: blinking the **onboard NeoPixel** in any color you want. 🌈
@@ -76,14 +82,6 @@ Upload this sketch and open the **Serial Monitor** at **115200 baud**. You shoul
 
 {: .warning }
 > **Native USB gotcha (ESP32-S3):** Because the ESP32-S3 uses native USB (not a separate USB-to-UART chip like the Uno's ATmega16U2 or the Huzzah32's CP2104), the serial port will **temporarily disappear** if the board crashes, resets, or enters deep sleep. If your Serial Monitor disconnects unexpectedly, just press the **Reset** button and reopen it. This is normal behavior for native USB—it's the same with the Arduino Leonardo.
-
-### Workbench video blinking built-in LED
-
-<video autoplay loop muted playsinline aria-label="Workbench video showing the Adafruit ESP32-S3 blinking the internal LED on GPIO 13">
-  <source src="assets/videos/ESP32-S3-BlinkyBuiltInLED-IMG_9348-Trimmed_optimized_muted.mp4" type="video/mp4">
-</video>
-**Video.** A workbench video of blinking the built-in LED on the Adafruit ESP32-S3.
-{: .fs-1 }
 
 ## Part 2: Blink an external LED
 

--- a/esp32/tone.md
+++ b/esp32/tone.md
@@ -19,6 +19,12 @@ nav_order: 5
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/H7MOhibjOO0" title="Playing the C scale on the ESP32 with a piezo buzzer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** A taste of what's ahead: an ESP32 playing a C major scale on a passive piezo buzzer. By the end of this lesson you'll be playing scales, melodies, and even the Imperial March. Make sure your sound is on.
+{: .fs-1 }
+
 <!-- Content TODOs:
 1. Record a workbench video of the scale/melody playing on a piezo buzzer with an ESP32-S3 Feather
 2. Record a video of the potentiometer-controlled tone with the ESP32-S3 Feather
@@ -36,9 +42,6 @@ nav_order: 5
 - https://github.com/espressif/arduino-esp32/pull/6402 (PR that added tone/noTone)
 - Our Arduino tone lesson: ../arduino/tone.md
 -->
-
-<!-- TODO: Add a hero video or animated GIF showing something fun built with the ESP32 and a piezo buzzer
-     (e.g., the potentiometer-controlled pitch demo, or the Imperial March playing) -->
 
 So far, every output we've produced in the ESP32 module has been visual—turning LEDs on, off, fading, and reading analog input. In this lesson, we'll add a completely new output modality: **sound!** Using a piezo buzzer and the `tone()` function, we'll learn how to play individual notes, scales, and even melodies on the ESP32.
 

--- a/sensors/hall-effect.md
+++ b/sensors/hall-effect.md
@@ -19,6 +19,12 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/MvVfq6AAEQU" title="Arduino-based magnetic LED brightener adjusting LED brightness in response to a moving magnet sensed by a Hall effect sensor" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** Where we're headed: an Arduino-driven "magical magnetic LED brightener" that smoothly fades an LED up and down as you move a magnet past a DRV5055 Hall effect sensor.
+{: .fs-1 }
+
 In this lesson, you will learn about two types of magnetic sensors: Hall effect sensors and reed switches. You will then use a [DRV5055](http://www.ti.com/lit/ds/symlink/drv5055.pdf) Hall effect sensor to build a simple auto-brightening LED circuit first without and then with a microcontroller.
 
 ## Introduction

--- a/sensors/photoresistors.md
+++ b/sensors/photoresistors.md
@@ -19,6 +19,12 @@ usetocbot: true
 {:toc}
 ---
 
+<div class="iframe-container">
+  <iframe width="100%" src="https://www.youtube.com/embed/CIhCJCBrOYU" title="Arduino auto-on nightlight brightening an LED as the room gets darker using a photoresistor" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+**Video.** By the end of this lesson, you'll have built an Arduino auto-on nightlight that brightens an LED as the room around it gets darker, all driven by a humble photoresistor.
+{: .fs-1 }
+
 In this lesson, you'll learn about [photoresistors](https://en.wikipedia.org/wiki/Photoresistor) and how to use them with and without microcontrollers.
 
 ## Photoresistors 


### PR DESCRIPTION
## What

Adds a captioned **hero media block immediately after the TOC** on 23 lesson pages, surfacing each lesson's climax demo as an opening hook. Follows the established pattern: descriptive iframe `title=` / video `aria-label=`, rotating forward-framing caption openers, and `{: .fs-1 }` captions.

### Pilot (12)
- `cpx/{analog-input,button-piano,capacitive-touch,cpx-keyboard,cpx-mouse,digital-input,makecode,sensor-instrument}` — YouTube/video demos lifted to top with descriptive iframe titles
- `communication/{p5js-serial-io,p5js-serial,serial-intro,web-serial}` — lesson-climax `<video>` demos with "preview of what we'll build" captions

### Rollout (11)
- `electronics/{electricity-basics,schematics,ohms-law}` (conceptual figures, duplicated at top)
- `arduino/{arduino-ide,rgb-led-fade,tone}` (tone uses `controls` not autoplay — has audio)
- `sensors/{hall-effect,photoresistors}` (YouTube — no self-hosted assets)
- `esp32/{led-blink,tone,iot}` (led-blink **relocates** its workbench video up; others duplicate)

## Placement rule
Hero-first: `TOC ---` → hero → optional "what you'll learn" note → prose. Duplicate vs. relocate by distance — relocate (remove lower copy) when the source sits right under the first heading; duplicate when the original lives far down as a genuine preview→payoff.

## Intentionally skipped (tracked in #122)
`arduino/inside-arduino`, `advancedio/servo`, `esp32/capacitive-touch` have only generic/placeholder media and need new media before they get a hero.

## Notes for review
- electronics heroes are conceptual figures duplicated at top + their original spot (schematics/ohms-law sit fairly high and prose references them "below" — glance for redundancy).
- sensors heroes are YouTube, not self-hosted.
- Optional follow-up: `generate_og_posters.py --run` on pages that newly gained an MP4 hero but lack `image:` (arduino/tone, esp32/led-blink).

## Verification
`bundle exec jekyll build` — clean (Jekyll 4, ~4.8s). 23 files, +130/-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)